### PR TITLE
bugfix #34027 - add rule for zalando when carrier is empty

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1251,6 +1251,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
             ShoppingfeedAddon\OrderImport\Rules\SymbolConformity::class,
             ShoppingfeedAddon\OrderImport\Rules\ManomanoDpdRelais::class,
             ShoppingfeedAddon\OrderImport\Rules\ZalandoColissimo::class,
+            ShoppingfeedAddon\OrderImport\Rules\ZalandoCarrier::class,
             ShoppingfeedAddon\OrderImport\Rules\ColizeyColissimo::class,
         ];
 

--- a/src/OrderImport/Rules/ZalandoCarrier.php
+++ b/src/OrderImport/Rules/ZalandoCarrier.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to a commercial license from SARL 202 ecommence
+ * Use, copy, modification or distribution of this source file without written
+ * license agreement from the SARL 202 ecommence is strictly forbidden.
+ * In order to obtain a license, please contact us: tech@202-ecommerce.com
+ * ...........................................................................
+ * INFORMATION SUR LA LICENCE D'UTILISATION
+ *
+ * L'utilisation de ce fichier source est soumise a une licence commerciale
+ * concedee par la societe 202 ecommence
+ * Toute utilisation, reproduction, modification ou distribution du present
+ * fichier source sans contrat de licence ecrit de la part de la SARL 202 ecommence est
+ * expressement interdite.
+ * Pour obtenir une licence, veuillez contacter 202-ecommerce <tech@202-ecommerce.com>
+ * ...........................................................................
+ *
+ * @author    202-ecommerce <tech@202-ecommerce.com>
+ * @copyright Copyright (c) 202-ecommerce
+ * @license   Commercial license
+ */
+
+namespace ShoppingfeedAddon\OrderImport\Rules;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use ShoppingFeed\Sdk\Api\Order\OrderResource;
+use ShoppingfeedAddon\OrderImport\RuleAbstract;
+use ShoppingfeedAddon\OrderImport\RuleInterface;
+use ShoppingfeedClasslib\Extensions\ProcessLogger\ProcessLoggerHandler;
+
+class ZalandoCarrier extends RuleAbstract implements RuleInterface
+{
+    public function isApplicable(OrderResource $apiOrder)
+    {
+        $apiOrderData = $apiOrder->toArray();
+        $logPrefix = sprintf(
+            $this->l('[Order: %s]', 'ZalandoCarrier'),
+            $apiOrder->getId()
+        );
+        $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
+        if (strcasecmp('zalandoboniclassic', $apiOrder->getChannel()->getName()) !== 0
+            && empty($apiOrderData['shipment']['carrier']) !== false) {
+            return false;
+        }
+
+        ProcessLoggerHandler::logInfo(
+            $logPrefix .
+                $this->l('Rule triggered.', 'ZalandoCarrier'),
+            'Order'
+        );
+
+        return true;
+    }
+
+    /**
+     * We have to do this on preprocess, as the fields may be used in various
+     * steps
+     *
+     * @param array $params
+     */
+    public function onCarrierRetrieval($params)
+    {
+        $apiOrder = $params['apiOrder'];
+        $apiOrderData = $apiOrder->toArray();
+        $carrier = (empty($apiOrderData['additionalFields']['service_point_id'])) ? 'standard' : 'pickup';
+        $params['apiOrderShipment']['carrier'] = $carrier;
+
+        $logPrefix = sprintf(
+            $this->l('[Order: %s]', 'ZalandoCarrier'),
+            $apiOrder->getId()
+        );
+        $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
+        ProcessLoggerHandler::logInfo(
+            $logPrefix .
+                $this->l("Rule triggered. Carrier set to $carrier", 'ZalandoCarrier'),
+            'Order'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConditions()
+    {
+        return $this->l('If the order comes from Zalando', 'ZalandoCarrier');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return $this->l('Set the carrier.', 'ZalandoCarrier');
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
