### PR TITLE
bugfix #34027 - add rule for zalando when carrier is empty

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1251,6 +1251,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
             ShoppingfeedAddon\OrderImport\Rules\SymbolConformity::class,
             ShoppingfeedAddon\OrderImport\Rules\ManomanoDpdRelais::class,
             ShoppingfeedAddon\OrderImport\Rules\ZalandoColissimo::class,
+            ShoppingfeedAddon\OrderImport\Rules\ZalandoCarrier::class,
             ShoppingfeedAddon\OrderImport\Rules\ColizeyColissimo::class,
         ];
 

--- a/src/OrderImport/Rules/ZalandoCarrier.php
+++ b/src/OrderImport/Rules/ZalandoCarrier.php
@@ -32,6 +32,7 @@ use ShoppingFeed\Sdk\Api\Order\OrderResource;
 use ShoppingfeedAddon\OrderImport\RuleAbstract;
 use ShoppingfeedAddon\OrderImport\RuleInterface;
 use ShoppingfeedClasslib\Extensions\ProcessLogger\ProcessLoggerHandler;
+use Tools;
 
 class ZalandoCarrier extends RuleAbstract implements RuleInterface
 {
@@ -43,18 +44,18 @@ class ZalandoCarrier extends RuleAbstract implements RuleInterface
             $apiOrder->getId()
         );
         $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
-        if (strcasecmp('zalandoboniclassic', $apiOrder->getChannel()->getName()) !== 0
-            || empty($apiOrderData['shipment']['carrier']) === false) {
-            return false;
+        if (preg_match('#^zalando#', Tools::strtolower($apiOrder->getChannel()->getName()))
+            && empty($apiOrderData['shipment']['carrier']) === false) {
+            ProcessLoggerHandler::logInfo(
+                    $logPrefix .
+                        $this->l('Rule triggered.', 'ZalandoCarrier'),
+                    'Order'
+                );
+
+            return true;
         }
 
-        ProcessLoggerHandler::logInfo(
-            $logPrefix .
-                $this->l('Rule triggered.', 'ZalandoCarrier'),
-            'Order'
-        );
-
-        return true;
+        return false;
     }
 
     /**

--- a/src/OrderImport/Rules/ZalandoCarrier.php
+++ b/src/OrderImport/Rules/ZalandoCarrier.php
@@ -44,7 +44,7 @@ class ZalandoCarrier extends RuleAbstract implements RuleInterface
         );
         $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
         if (strcasecmp('zalandoboniclassic', $apiOrder->getChannel()->getName()) !== 0
-            && empty($apiOrderData['shipment']['carrier']) !== false) {
+            || empty($apiOrderData['shipment']['carrier']) === false) {
             return false;
         }
 

--- a/src/OrderImport/Rules/ZalandoCarrier.php
+++ b/src/OrderImport/Rules/ZalandoCarrier.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to a commercial license from SARL 202 ecommence
+ * Use, copy, modification or distribution of this source file without written
+ * license agreement from the SARL 202 ecommence is strictly forbidden.
+ * In order to obtain a license, please contact us: tech@202-ecommerce.com
+ * ...........................................................................
+ * INFORMATION SUR LA LICENCE D'UTILISATION
+ *
+ * L'utilisation de ce fichier source est soumise a une licence commerciale
+ * concedee par la societe 202 ecommence
+ * Toute utilisation, reproduction, modification ou distribution du present
+ * fichier source sans contrat de licence ecrit de la part de la SARL 202 ecommence est
+ * expressement interdite.
+ * Pour obtenir une licence, veuillez contacter 202-ecommerce <tech@202-ecommerce.com>
+ * ...........................................................................
+ *
+ * @author    202-ecommerce <tech@202-ecommerce.com>
+ * @copyright Copyright (c) 202-ecommerce
+ * @license   Commercial license
+ */
+
+namespace ShoppingfeedAddon\OrderImport\Rules;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use ShoppingFeed\Sdk\Api\Order\OrderResource;
+use ShoppingfeedAddon\OrderImport\RuleAbstract;
+use ShoppingfeedAddon\OrderImport\RuleInterface;
+use ShoppingfeedClasslib\Extensions\ProcessLogger\ProcessLoggerHandler;
+
+class ZalandoCarrier extends RuleAbstract implements RuleInterface
+{
+    public function isApplicable(OrderResource $apiOrder)
+    {
+        $apiOrderData = $apiOrder->toArray();
+        $logPrefix = sprintf(
+            $this->l('[Order: %s]', 'ZalandoCarrier'),
+            $apiOrder->getId()
+        );
+        $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
+        if (strcasecmp('zalandoboniclassic', $apiOrder->getChannel()->getName()) !== 0
+            && empty($apiOrderData['shipment']['carrier']) !== false) {
+            return false;
+        }
+
+        ProcessLoggerHandler::logInfo(
+            $logPrefix .
+                $this->l('Rule triggered.', 'ZalandoCarrier'),
+            'Order'
+        );
+
+        return true;
+    }
+
+    /**
+     * We have to do this on preprocess, as the fields may be used in various
+     * steps
+     *
+     * @param array $params
+     */
+    public function onCarrierRetrieval($params)
+    {
+        $apiOrder = $params['apiOrder'];
+        $apiOrderData = $apiOrder->toArray();
+        $carrier = (empty($apiOrderData['additionalFields']['service_point_id'])) ? 'standard' : 'pickup';
+        $params['apiOrderShipment']['carrier'] = $carrier;
+
+        $logPrefix = sprintf(
+            $this->l('[Order: %s]', 'ZalandoCarrier'),
+            $apiOrder->getId()
+        );
+        $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
+        ProcessLoggerHandler::logInfo(
+            $logPrefix .
+                $this->l("Rule triggered. Carrier set to $carrier", 'ZalandoCarrier'),
+            'Order'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConditions()
+    {
+        return $this->l('If the order comes from Zalando', 'ZalandoCarrier');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return $this->l('Set the carrier.', 'ZalandoCarrier');
+    }
+}

--- a/src/OrderImport/Rules/ZalandoColissimo.php
+++ b/src/OrderImport/Rules/ZalandoColissimo.php
@@ -32,6 +32,7 @@ use Module;
 use ShoppingFeed\Sdk\Api\Order\OrderResource;
 use ShoppingfeedAddon\OrderImport\RuleInterface;
 use ShoppingfeedClasslib\Extensions\ProcessLogger\ProcessLoggerHandler;
+use Tools;
 
 /**
  * See ticket #30781
@@ -51,7 +52,8 @@ class ZalandoColissimo extends AbstractColissimo implements RuleInterface
         $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
 
         // Check marketplace, that the additional fields with the pickup point data are there and not empty, and that the "colissimo" module is installed and active
-        if ($this->isModuleColissimoEnabled()
+        if (preg_match('#^zalando#', Tools::strtolower($apiOrder->getChannel()->getName()))
+            && $this->isModuleColissimoEnabled()
             && !empty($apiOrderData['additionalFields']['service_point_id'])
             && !empty($apiOrderData['additionalFields']['service_point_name'])
         ) {

--- a/upgrade/install-1.6.3.php
+++ b/upgrade/install-1.6.3.php
@@ -21,7 +21,6 @@
  * @copyright Copyright (c) 202-ecommerce
  * @license   Commercial license
  */
-
 function upgrade_module_1_6_3($module)
 {
     if (Shop::isFeatureActive()) {

--- a/upgrade/install-1.6.3.php
+++ b/upgrade/install-1.6.3.php
@@ -21,6 +21,7 @@
  * @copyright Copyright (c) 202-ecommerce
  * @license   Commercial license
  */
+
 function upgrade_module_1_6_3($module)
 {
     if (Shop::isFeatureActive()) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Zalando don't supply the carrier name. That may cause trouble for merchand that want map to a carrier different than Colissimo
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 34027
| How to test?  | Use Unit test
