### PR TITLE
bugfix #34027 - fix condition isApplicable

### DIFF
--- a/202/tests/OrderImport/OrderImportSimpleTest.php
+++ b/202/tests/OrderImport/OrderImportSimpleTest.php
@@ -21,6 +21,7 @@ namespace Tests\OrderImport;
 
 use ColissimoCartPickupPoint;
 use ShoppingfeedAddon\Actions\ActionsHandler;
+use ShoppingfeedCarrier;
 use ShoppingfeedClasslib\Registry;
 
 /**
@@ -272,6 +273,11 @@ class OrderImportSimpleTest extends AbstractOrdeTestCase
         $this->assertEquals($pickupPoint->company_name, 'PRIMAVERA');
         $this->assertEquals($pickupPoint->product_code, 'BPR');
         $this->assertEquals($pickupPoint->city, 'MARSEILLE');
+        $sfCarrier = ShoppingfeedCarrier::getByMarketplaceAndName(
+                        'zalandomyunittest',
+                        'pickup'
+                    );
+        $this->assertNotEquals($sfCarrier, false);
     }
 
     public function testImportColizey(): void

--- a/src/OrderImport/Rules/ZalandoCarrier.php
+++ b/src/OrderImport/Rules/ZalandoCarrier.php
@@ -45,7 +45,7 @@ class ZalandoCarrier extends RuleAbstract implements RuleInterface
         );
         $logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
         if (preg_match('#^zalando#', Tools::strtolower($apiOrder->getChannel()->getName()))
-            && empty($apiOrderData['shipment']['carrier']) === false) {
+            && empty($apiOrderData['shipment']['carrier'])) {
             ProcessLoggerHandler::logInfo(
                     $logPrefix .
                         $this->l('Rule triggered.', 'ZalandoCarrier'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Zalando don't supply the carrier name. That may cause trouble for merchand that want map to a carrier different than Colissimo
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #34027
| How to test?  | Use Unit test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
