### PR TITLE
fix amount of tax in case of tax rules with several taxes

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                presta-versions: ['1.7.8.3']
+                presta-versions: ['1.7.8.5']
         steps:
             - name: Checkout
               uses: actions/checkout@v2.0.0

--- a/202/docker/Dockerfile
+++ b/202/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM 202ecommerce/prestashop:1.7.8.3
+FROM 202ecommerce/prestashop:1.7.8.5
 
 RUN rm -Rf var/www/html/modules/shoppingfeed/
 

--- a/202/docker/entrypoint.sh
+++ b/202/docker/entrypoint.sh
@@ -30,6 +30,18 @@ INSERT IGNORE INTO ps_shoppingfeed_token (id_shoppingfeed_token, id_shop, id_lan
 INSERT IGNORE INTO ps_shoppingfeed_carrier (id_shoppingfeed_carrier, name_marketplace, name_carrier, id_carrier_reference, is_new, date_add, date_upd) VALUES
 (1,	'Amazon',	'Colissimo',	1,	0,	'2022-02-17 00:00:00',	'2022-02-17 00:00:00'),
 (2,	'NatureEtDecouvertes',	'Point Relais (Chrono Relais)',	2,	0,	'2022-02-17 07:44:26',	'2022-02-17 00:00:00');
+INSERT IGNORE INTO ps_tax (id_tax, rate, active, deleted) VALUES
+(40, 0.190, 1, 0);
+INSERT IGNORE INTO ps_tax_lang (id_tax, id_lang, name) VALUES
+(40, 1, 'TPH'), (40, 2, 'TPH');
+INSERT IGNORE INTO ps_tax_rules_group (id_tax_rules_group, name, active, deleted, date_add, date_upd) VALUES
+(10, 'TVA + TPH', 1, 0, NOW(), NOW());
+INSERT IGNORE INTO ps_tax_rules_group_shop (id_tax_rules_group, id_shop) VALUES (10, 1);
+INSERT IGNORE INTO ps_tax_rule (id_tax_rules_group, id_country, id_state, zipcode_from, zipcode_to, id_tax, behavior) VALUES
+(10, 8, 0, 0, 0, 40, 2),
+(10, 8, 0, 0, 0, 1, 2);
+UPDATE ps_product SET id_tax_rules_group = 10 WHERE id_product = 18;
+UPDATE ps_product_shop SET id_tax_rules_group = 10 WHERE id_product = 18;
 "
 
 chown $RUN_USER:$RUN_USER /var/www/html -Rf

--- a/202/docker/run_for_unittest.sh
+++ b/202/docker/run_for_unittest.sh
@@ -18,6 +18,19 @@ UPDATE ps_configuration SET value = '[\"6\"]' WHERE name = 'SHOPPINGFEED_CANCELL
 UPDATE ps_configuration SET value = '[\"7\"]' WHERE name = 'SHOPPINGFEED_REFUNDED_ORDERS';
 UPDATE ps_configuration SET value = '{\"ShoppingfeedAddon\\OrderImport\\Rules\\AmazonEbay\":{\"enabled\":\"1\"},\"ShoppingfeedAddon\\OrderImport\\Rules\\ChangeStateOrder\":{\"end_order_state\":\"\"},\"ShoppingfeedAddon\\OrderImport\\Rules\\ShippedByMarketplace\":{\"end_order_state_shipped\":\"5\"},\"ShoppingfeedAddon\\OrderImport\\Rules\\SymbolConformity\":{\"enabled\":\"1\"}}' WHERE name = 'SHOPPINGFEED_ORDER_IMPORT_SPECIFIC_RULES_CONFIGURATION';
 
+INSERT IGNORE INTO ps_tax (id_tax, rate, active, deleted) VALUES
+(40, 0.190, 1, 0);
+INSERT IGNORE INTO ps_tax_lang (id_tax, id_lang, name) VALUES
+(40, 1, 'TPH'), (40, 2, 'TPH');
+INSERT IGNORE INTO ps_tax_rules_group (id_tax_rules_group, name, active, deleted, date_add, date_upd) VALUES
+(10, 'TVA + TPH', 1, 0, NOW(), NOW());
+INSERT IGNORE INTO ps_tax_rules_group_shop (id_tax_rules_group, id_shop) VALUES (10, 1);
+INSERT IGNORE INTO ps_tax_rule (id_tax_rules_group, id_country, id_state, zipcode_from, zipcode_to, id_tax, behavior) VALUES
+(10, 8, 0, 0, 0, 40, 2),
+(10, 8, 0, 0, 0, 1, 2);
+UPDATE ps_product SET id_tax_rules_group = 10 WHERE id_product = 18;
+UPDATE ps_product_shop SET id_tax_rules_group = 10 WHERE id_product = 18;
+
 INSERT IGNORE INTO ps_shoppingfeed_token (id_shoppingfeed_token, id_shop, id_lang, id_currency, content, active, date_add, date_upd) VALUES
 (1, 1, 1, 1, 'token-shoppingfeed-api', 1, NOW(), NOW());
 

--- a/202/tests/OrderImport/OrderImportSimpleTest.php
+++ b/202/tests/OrderImport/OrderImportSimpleTest.php
@@ -451,7 +451,7 @@ class OrderImportSimpleTest extends AbstractOrdeTestCase
         //refs#34500
         $detail = $psOrder->getProductsDetail()[0];
         $detailTaxes = \OrderDetail::getTaxListStatic($detail['id_order_detail']);
-        $this->assertEquals($detailTaxes[0]['total_amount'], 1.620000);
+        $this->assertEquals($detailTaxes[0]['total_amount'], 1.630000);
         $this->assertEquals($detailTaxes[0]['id_tax'], 1);
         $this->assertEquals($detailTaxes[1]['total_amount'], 0.010000);
         $this->assertEquals($detailTaxes[1]['id_tax'], 40);

--- a/202/tests/OrderImport/OrderImportSimpleTest.php
+++ b/202/tests/OrderImport/OrderImportSimpleTest.php
@@ -451,7 +451,7 @@ class OrderImportSimpleTest extends AbstractOrdeTestCase
         //refs#34500
         $detail = $psOrder->getProductsDetail()[0];
         $detailTaxes = \OrderDetail::getTaxListStatic($detail['id_order_detail']);
-        $this->assertEquals($detailTaxes[0]['total_amount'], 1.630000);
+        $this->assertEquals($detailTaxes[0]['total_amount'], 1.620000);
         $this->assertEquals($detailTaxes[0]['id_tax'], 1);
         $this->assertEquals($detailTaxes[1]['total_amount'], 0.010000);
         $this->assertEquals($detailTaxes[1]['id_tax'], 40);

--- a/202/tests/OrderImport/OrderImportSimpleTest.php
+++ b/202/tests/OrderImport/OrderImportSimpleTest.php
@@ -371,7 +371,7 @@ class OrderImportSimpleTest extends AbstractOrdeTestCase
      *
      * @return void
      */
-    public function testImportManoManoDpdRelais(): void
+    public function testImportManoManoDpdRelaisWithDoubleTaxOnProduct(): void
     {
         $apiOrder = $this->getOrderRessourceFromDataset('order-manomano.json');
 
@@ -447,5 +447,13 @@ class OrderImportSimpleTest extends AbstractOrdeTestCase
         $dpdShippingService = \Dpdfrance::getService($psOrder, false);
         $expectedValue = 'REL';
         $this->assertEquals($expectedValue, $dpdShippingService);
+
+        //refs#34500
+        $detail = $psOrder->getProductsDetail()[0];
+        $detailTaxes = \OrderDetail::getTaxListStatic($detail['id_order_detail']);
+        $this->assertEquals($detailTaxes[0]['total_amount'], 1.620000);
+        $this->assertEquals($detailTaxes[0]['id_tax'], 1);
+        $this->assertEquals($detailTaxes[1]['total_amount'], 0.010000);
+        $this->assertEquals($detailTaxes[1]['id_tax'], 40);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If imported order need apply a tax rules with VAT and a second tax like TPH, the module dosn't compute the good taxes amounts.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 34618
| How to test?  | Unit tests added
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
