### PR TITLE
Add shipped by marketplace on getUnacknowledgedOrders

### DIFF
--- a/controllers/front/syncOrder.php
+++ b/controllers/front/syncOrder.php
@@ -295,7 +295,8 @@ class ShoppingfeedSyncOrderModuleFrontController extends ShoppingfeedCronControl
                 }
 
                 $result = $shoppingfeedApi->getUnacknowledgedOrders();
-                if (Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED) == true) {
+                if (Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED) == true
+                    || Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE) == true) {
                     $result = array_merge($result, $shoppingfeedApi->getUnacknowledgedOrders(true));
                 }
             } catch (Exception $e) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In case of shipped by MarketPlace but without "already shipped" import order, orders shipped by MarketPlace are not imported.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 34645
| How to test?  | See support tickets.