### PR TITLE
Fix uncatch error if empty cart just before valdiateOrder

### DIFF
--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -720,6 +720,16 @@ class ShoppingfeedOrderImportActions extends DefaultActions
         $this->conveyor['customer']->update();
 
         $amount_paid = (float) Tools::ps_round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
+        if ($cart->nbProducts() === 0) {
+            $this->conveyor['error'] = sprintf(
+                    $this->l('Could not add product to cart : %s', 'ShoppingfeedOrderImportActions'),
+                    $cart->id
+                );
+            ProcessLoggerHandler::logError($this->logPrefix . $this->conveyor['error'], 'Order');
+            $this->forward('acknowledgeOrder');
+
+            return false;
+        }
         try {
             $paymentModule->validateOrder(
                 (int) $cart->id,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  uncatch error if empty cart just before valdiateOrder
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 34615
| How to test?  | impossible to reproduce with a native PrestaShop.
