### PR TITLE
Disabled old order sync ticket 

### DIFF
--- a/202/tests/OrderSync/TaskOrderCleanerTest.php
+++ b/202/tests/OrderSync/TaskOrderCleanerTest.php
@@ -19,18 +19,18 @@
 
 namespace Tests\OrderSync;
 
+use DateTime;
+use Db;
+use DbQuery;
 use PHPUnit\Framework\TestCase;
 use ShoppingfeedAddon\Services\TaskOrderCleaner;
 use ShoppingfeedTaskOrder;
-use Db;
-use DbQuery;
-use DateTime;
 
 class TaskOrderCleanerTest extends TestCase
 {
     public function testTaskOrderCleaner()
     {
-        $sql = (new DbQuery())->select('count(*)')->from(ShoppingfeedTaskOrder::$definition['table']);;
+        $sql = (new DbQuery())->select('count(*)')->from(ShoppingfeedTaskOrder::$definition['table']);
         $countTaskOrder = Db::getInstance()->getValue($sql);
         $taskOrderCleaner = new TaskOrderCleaner();
 

--- a/202/tests/OrderSync/TaskOrderCleanerTest.php
+++ b/202/tests/OrderSync/TaskOrderCleanerTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2019 Shopping Feed
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright Since 2019 Shopping Feed
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace Tests\OrderSync;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingfeedAddon\Services\TaskOrderCleaner;
+use ShoppingfeedTaskOrder;
+use Db;
+use DbQuery;
+use DateTime;
+
+class TaskOrderCleanerTest extends TestCase
+{
+    public function testTaskOrderCleaner()
+    {
+        $sql = (new DbQuery())->select('count(*)')->from(ShoppingfeedTaskOrder::$definition['table']);;
+        $countTaskOrder = Db::getInstance()->getValue($sql);
+        $taskOrderCleaner = new TaskOrderCleaner();
+
+        $shoppingfeedTaskOrder = new ShoppingfeedTaskOrder();
+        $shoppingfeedTaskOrder->action = ShoppingfeedTaskOrder::ACTION_SYNC_STATUS;
+        $shoppingfeedTaskOrder->id_order = 1;
+        $shoppingfeedTaskOrder->save();
+        $taskOrderCleaner->clean();
+        $this->assertEquals(Db::getInstance()->getValue($sql), $countTaskOrder + 1);
+
+        $shoppingfeedTaskOrder->date_add = (new DateTime())->modify('-8 day')->format('Y-m-d H:i:s');
+        $shoppingfeedTaskOrder->save();
+        $taskOrderCleaner->clean();
+
+        $this->assertEquals(Db::getInstance()->getValue($sql), $countTaskOrder);
+    }
+}

--- a/classes/ShoppingfeedOrder.php
+++ b/classes/ShoppingfeedOrder.php
@@ -51,6 +51,8 @@ class ShoppingfeedOrder extends ObjectModel
     public $date_add;
     public $date_upd;
 
+    public $failed_ticket;
+
     public static $definition = [
         'table' => 'shoppingfeed_order',
         'primary' => 'id_shoppingfeed_order',

--- a/classes/ShoppingfeedOrder.php
+++ b/classes/ShoppingfeedOrder.php
@@ -95,6 +95,11 @@ class ShoppingfeedOrder extends ObjectModel
                 'required' => true,
                 'allow_null' => true,
             ],
+            'failed_ticket' => [
+                'type' => ObjectModel::TYPE_INT,
+                'validate' => 'isInt',
+                'allow_null' => true,
+            ],
             'date_add' => [
                 'type' => self::TYPE_DATE,
                 'validate' => 'isDate',

--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -19,6 +19,7 @@
 
 use ShoppingFeed\Sdk\Api\Order\OrderOperation;
 use ShoppingfeedAddon\Services\CarrierFinder;
+use ShoppingfeedAddon\Services\TaskOrderCleaner;
 use ShoppingfeedClasslib\Actions\DefaultActions;
 use ShoppingfeedClasslib\Extensions\ProcessLogger\ProcessLoggerHandler;
 use ShoppingfeedClasslib\Registry;
@@ -187,6 +188,8 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
             return false;
         }
         $id_shop = (int) $this->conveyor['id_shop'];
+        //Remove old tasks
+        $this->initTaskCleaner()->clean();
 
         if (empty($this->conveyor['order_action'])) {
             ProcessLoggerHandler::logInfo(
@@ -804,5 +807,10 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
         }
 
         return true;
+    }
+
+    protected function initTaskCleaner()
+    {
+        return new TaskOrderCleaner();
     }
 }

--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -655,13 +655,27 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
 
         // Get order data
         $failedTaskOrdersMailData = [];
+
         foreach ($failedTaskOrders as $taskOrder) {
             $order = new Order($taskOrder->id_order);
             $orderState = new OrderState($order->current_state);
+            $sfOrder = ShoppingfeedOrder::getByIdOrder($order->id);
+
+            // Send mail only once
+            if ($sfOrder->failed_ticket == 1) {
+                continue;
+            }
+
+            $sfOrder->failed_ticket = 1;
+            $sfOrder->save();
             $failedTaskOrdersMailData[] = [
                 'reference' => $order->reference,
                 'status' => !empty($orderState->name[$id_lang]) ? $orderState->name[$id_lang] : reset($orderState->name),
             ];
+        }
+
+        if (empty($failedTaskOrdersMailData)) {
+            return true;
         }
 
         $listFailuresHtml = $this->getEmailTemplateContent(

--- a/src/Services/TaskOrderCleaner.php
+++ b/src/Services/TaskOrderCleaner.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ *  Copyright since 2019 Shopping Feed
+ *
+ *  NOTICE OF LICENSE
+ *
+ *  This source file is subject to the Academic Free License (AFL 3.0)
+ *  that is bundled with this package in the file LICENSE.md.
+ *  It is also available through the world-wide-web at this URL:
+ *  https://opensource.org/licenses/AFL-3.0
+ *  If you did not receive a copy of the license and are unable to
+ *  obtain it through the world-wide-web, please send an email
+ *  to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ *  @author    202 ecommerce <tech@202-ecommerce.com>
+ *  @copyright Since 2019 Shopping Feed
+ *  @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace ShoppingfeedAddon\Services;
+
+use Db;
+use ShoppingfeedTaskOrder;
+
+class TaskOrderCleaner
+{
+    protected $db;
+
+    public function __construct()
+    {
+        $this->db = Db::getInstance();
+    }
+
+    public function clean($period = 7)
+    {
+        $where = sprintf(
+            'NOW() > DATE_ADD(date_add, INTERVAL %d day)',
+            (int) $period
+        );
+
+        return $this->db->delete(ShoppingfeedTaskOrder::$definition['table'], $where);
+    }
+}

--- a/upgrade/install-1.8.0.php
+++ b/upgrade/install-1.8.0.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ *  Copyright since 2019 Shopping Feed
+ *
+ *  NOTICE OF LICENSE
+ *
+ *  This source file is subject to the Academic Free License (AFL 3.0)
+ *  that is bundled with this package in the file LICENSE.md.
+ *  It is also available through the world-wide-web at this URL:
+ *  https://opensource.org/licenses/AFL-3.0
+ *  If you did not receive a copy of the license and are unable to
+ *  obtain it through the world-wide-web, please send an email
+ *  to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ *  @author    202 ecommerce <tech@202-ecommerce.com>
+ *  @copyright Since 2019 Shopping Feed
+ *  @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+function upgrade_module_1_8_0($module)
+{
+    $installer = new \ShoppingfeedClasslib\Install\ModuleInstaller($module);
+    $installer->installObjectModel(ShoppingfeedOrder::class);
+
+    return true;
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -1778,6 +1778,7 @@ return array(
     'ShoppingfeedAddon\\Services\\ShopSqlAssociator' => $baseDir . '/src/Services/ShopSqlAssociator.php',
     'ShoppingfeedAddon\\Services\\SpecificPriceService' => $baseDir . '/src/Services/SpecificPriceService.php',
     'ShoppingfeedAddon\\Services\\SymbolValidator' => $baseDir . '/src/Services/SymbolValidator.php',
+    'ShoppingfeedAddon\\Services\\TaskOrderCleaner' => $baseDir . '/src/Services/TaskOrderCleaner.php',
     'ShoppingfeedAdminController' => $baseDir . '/classes/ShoppingfeedAdminController.php',
     'ShoppingfeedApi' => $baseDir . '/classes/ShoppingfeedApi.php',
     'ShoppingfeedCarrier' => $baseDir . '/classes/ShoppingfeedCarrier.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -2038,6 +2038,7 @@ class ComposerStaticInit3fe85f86ff701f6bd7fd7d7a118b5533
         'ShoppingfeedAddon\\Services\\ShopSqlAssociator' => __DIR__ . '/../..' . '/src/Services/ShopSqlAssociator.php',
         'ShoppingfeedAddon\\Services\\SpecificPriceService' => __DIR__ . '/../..' . '/src/Services/SpecificPriceService.php',
         'ShoppingfeedAddon\\Services\\SymbolValidator' => __DIR__ . '/../..' . '/src/Services/SymbolValidator.php',
+        'ShoppingfeedAddon\\Services\\TaskOrderCleaner' => __DIR__ . '/../..' . '/src/Services/TaskOrderCleaner.php',
         'ShoppingfeedAdminController' => __DIR__ . '/../..' . '/classes/ShoppingfeedAdminController.php',
         'ShoppingfeedApi' => __DIR__ . '/../..' . '/classes/ShoppingfeedApi.php',
         'ShoppingfeedCarrier' => __DIR__ . '/../..' . '/classes/ShoppingfeedCarrier.php',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In case of mismatch between the order state on PrestaShop and ShoppingFeed, the module retry to send PrestaShop state that trigger a failed response.<br>The module sould send the error only once and retry only during 7 days
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 34100
| How to test?  | Cover by Unit tests