### PR TITLE
Recalculating splitted order

### DIFF
--- a/202/docker/run_for_unittest.sh
+++ b/202/docker/run_for_unittest.sh
@@ -47,6 +47,12 @@ UPDATE ps_product_lang SET available_now = 'disponible', available_later = 'non 
 UPDATE ps_stock_available SET quantity = 0 WHERE id_product = 3 and id_product_attribute = 13;
 UPDATE ps_stock_available SET quantity = 0 WHERE id_product = 4 and id_product_attribute = 16;
 
+DELETE FROM ps_product_carrier WHERE id_product IN (1,8);
+REPLACE INTO ps_product_carrier (id_product, id_carrier_reference, id_shop) VALUES
+(1,1,1), (8,2,1);
+REPLACE INTO ps_carrier_zone (id_carrier, id_zone) VALUES
+(1,9), (2,9);
+
 TRUNCATE ps_colissimo_pickup_point;
 "
 

--- a/202/tests/OrderImport/OrderImportSimpleTest.php
+++ b/202/tests/OrderImport/OrderImportSimpleTest.php
@@ -20,6 +20,8 @@
 namespace Tests\OrderImport;
 
 use ColissimoCartPickupPoint;
+use Db;
+use Order;
 use ShoppingfeedAddon\Actions\ActionsHandler;
 use ShoppingfeedCarrier;
 use ShoppingfeedClasslib\Registry;
@@ -455,5 +457,87 @@ class OrderImportSimpleTest extends AbstractOrdeTestCase
         $this->assertEquals($detailTaxes[0]['id_tax'], 1);
         $this->assertEquals($detailTaxes[1]['total_amount'], 0.010000);
         $this->assertEquals($detailTaxes[1]['id_tax'], 40);
+    }
+
+    public function setDifferentCarrierForProducts()
+    {
+        $query = (new \DbQuery())
+            ->from('carrier')
+            ->where('active = 1')
+            ->where('deleted = 0')
+            ->select('id_reference')
+            ->limit(2);
+        $carriers = Db::getInstance()->execute($query);
+
+        if (empty($carriers)) {
+            return false;
+        }
+
+        if (count($carriers) < 2) {
+            return false;
+        }
+
+        //Remove existing product-carrier associations
+        Db::getInstance()->delete('product_carrier', 'id_product in (1, 8)');
+        //Add the new product-carrier associations
+        $insertData = [
+            [
+                'id_product' => 1,
+                'id_carrier_reference' => $carriers[0]['id_reference'],
+                'id_shop' => 1,
+            ],
+            [
+                'id_product' => 8,
+                'id_carrier_reference' => $carriers[1]['id_reference'],
+                'id_shop' => 1,
+            ],
+        ];
+
+        return Db::getInstance()->insert('product_carrier', $insertData, false, true, Db::REPLACE);
+    }
+
+    /**
+     * @depends setDifferentCarrierForProducts
+     */
+    public function testImportSplittedOrder($isDifferentCarriersSet)
+    {
+        $this->assertTrue($isDifferentCarriersSet);
+
+        $apiOrder = $this->getOrderRessourceFromDataset('order-for-splitting.json');
+
+        $handler = new ActionsHandler();
+        $handler->addActions(
+            'registerSpecificRules',
+            'verifyOrder',
+            'createOrderCart',
+            'validateOrder',
+            'postProcess'
+        );
+
+        $handler->setConveyor(
+            [
+                'id_shop' => 1,
+                'id_token' => 1,
+                'apiOrder' => $apiOrder,
+            ]
+        );
+        Registry::set('shoppingfeedOrderImportHandler', $handler);
+
+        $processResult = $handler->process('shoppingfeedOrderImport');
+
+        $this->assertTrue($processResult);
+        $conveyor = $handler->getConveyor();
+
+        $orders = (new \PrestaShopCollection('Order'))
+            ->where('id_cart', '=', $conveyor['psOrder']->id_cart)
+            ->getResults();
+        $totalAmount = 0;
+        /** @var Order $order */
+        foreach ($orders as $order) {
+            $totalAmount += $order->total_paid_tax_incl;
+        }
+
+        $this->assertTrue(count($orders) == 2);
+        $this->assertTrue(round($totalAmount, 2) == 19.40);
     }
 }

--- a/202/tests/OrderImport/OrderSplittingTest.php
+++ b/202/tests/OrderImport/OrderSplittingTest.php
@@ -35,7 +35,7 @@ class OrderSplittingTest extends AbstractOrdeTestCase
             ->from('carrier')
             ->where('active = 1')
             ->where('deleted = 0')
-            ->select('id_reference')
+            ->select('id_reference, id_carrier')
             ->limit(2);
         $carriers = Db::getInstance()->executeS($query);
 
@@ -62,6 +62,20 @@ class OrderSplittingTest extends AbstractOrdeTestCase
 
         $isDifferentCarriersSet = Db::getInstance()->insert('product_carrier', $insertData, false, true, Db::REPLACE);
         $this->assertTrue($isDifferentCarriersSet);
+
+        $country = new \Country(\Country::getByIso('fr'));
+        $insertData = [
+            [
+                'id_carrier' => $carriers[0]['id_carrier'],
+                'id_zone' => $country->id_zone,
+            ],
+            [
+                'id_carrier' => $carriers[1]['id_carrier'],
+                'id_zone' => $country->id_zone,
+            ],
+        ];
+        $isCarrierZoneSet = Db::getInstance()->insert('carrier_zone', $insertData, false, true, Db::REPLACE);
+        $this->assertTrue($isCarrierZoneSet);
     }
 
     /**
@@ -107,6 +121,7 @@ class OrderSplittingTest extends AbstractOrdeTestCase
             $totalProduct += $order->total_products_wt;
         }
 
+        $this->assertEquals(2, count($orders));
         $this->assertEquals(19.40, round($totalAmount, 2));
         $this->assertEquals(4.90, round($totalShipping, 2));
         $this->assertEquals(14.50, round($totalProduct, 2));

--- a/202/tests/OrderImport/OrderSplittingTest.php
+++ b/202/tests/OrderImport/OrderSplittingTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ *  Copyright since 2019 Shopping Feed
+ *
+ *  NOTICE OF LICENSE
+ *
+ *  This source file is subject to the Academic Free License (AFL 3.0)
+ *  that is bundled with this package in the file LICENSE.md.
+ *  It is also available through the world-wide-web at this URL:
+ *  https://opensource.org/licenses/AFL-3.0
+ *  If you did not receive a copy of the license and are unable to
+ *  obtain it through the world-wide-web, please send an email
+ *  to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ *  @author    202 ecommerce <tech@202-ecommerce.com>
+ *  @copyright Since 2019 Shopping Feed
+ *  @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace Tests\OrderImport;
+
+use Db;
+use Order;
+use ShoppingfeedAddon\Actions\ActionsHandler;
+use ShoppingfeedClasslib\Registry;
+
+/**
+ * Order Rules AmazonEbay Test
+ */
+class OrderSplittingTest extends AbstractOrdeTestCase
+{
+    public function setDifferentCarrierForProducts()
+    {
+        $query = (new \DbQuery())
+            ->from('carrier')
+            ->where('active = 1')
+            ->where('deleted = 0')
+            ->select('id_reference')
+            ->limit(2);
+        $carriers = Db::getInstance()->execute($query);
+
+        if (empty($carriers)) {
+            return false;
+        }
+
+        if (count($carriers) < 2) {
+            return false;
+        }
+
+        //Remove existing product-carrier associations
+        Db::getInstance()->delete('product_carrier', 'id_product in (1, 8)');
+        //Add the new product-carrier associations
+        $insertData = [
+            [
+                'id_product' => 1,
+                'id_carrier_reference' => $carriers[0]['id_reference'],
+                'id_shop' => 1,
+            ],
+            [
+                'id_product' => 8,
+                'id_carrier_reference' => $carriers[1]['id_reference'],
+                'id_shop' => 1,
+            ],
+        ];
+
+        return Db::getInstance()->insert('product_carrier', $insertData, false, true, Db::REPLACE);
+    }
+
+    /**
+     * @depends setDifferentCarrierForProducts
+     */
+    public function testImportSplittedOrder($isDifferentCarriersSet)
+    {
+        $this->assertTrue($isDifferentCarriersSet);
+
+        $apiOrder = $this->getOrderRessourceFromDataset('order-for-splitting.json');
+
+        $handler = new ActionsHandler();
+        $handler->addActions(
+            'registerSpecificRules',
+            'verifyOrder',
+            'createOrderCart',
+            'validateOrder',
+            'postProcess'
+        );
+
+        $handler->setConveyor(
+            [
+                'id_shop' => 1,
+                'id_token' => 1,
+                'apiOrder' => $apiOrder,
+            ]
+        );
+        Registry::set('shoppingfeedOrderImportHandler', $handler);
+
+        $processResult = $handler->process('shoppingfeedOrderImport');
+
+        $this->assertTrue($processResult);
+        $conveyor = $handler->getConveyor();
+
+        $orders = (new \PrestaShopCollection('Order'))
+            ->where('id_cart', '=', $conveyor['psOrder']->id_cart)
+            ->getResults();
+        $totalAmount = 0;
+        $totalShipping = 0;
+        $totalProduct = 0;
+        /** @var Order $order */
+        foreach ($orders as $order) {
+            $totalAmount += $order->total_paid_tax_incl;
+            $totalShipping += $order->total_shipping;
+            $totalProduct += $order->total_products;
+        }
+
+        $this->assertTrue(count($orders) == 2);
+        $this->assertTrue(round($totalAmount, 2) == 19.40);
+        $this->assertTrue(round($totalShipping, 2) == 4.90);
+        $this->assertTrue(round($totalProduct, 2) == 14.50);
+    }
+}

--- a/202/tests/OrderImport/OrderSplittingTest.php
+++ b/202/tests/OrderImport/OrderSplittingTest.php
@@ -19,7 +19,6 @@
 
 namespace Tests\OrderImport;
 
-use Db;
 use Order;
 use ShoppingfeedAddon\Actions\ActionsHandler;
 use ShoppingfeedClasslib\Registry;
@@ -29,58 +28,6 @@ use ShoppingfeedClasslib\Registry;
  */
 class OrderSplittingTest extends AbstractOrdeTestCase
 {
-    public function testSetDifferentCarrierForProducts()
-    {
-        $query = (new \DbQuery())
-            ->from('carrier')
-            ->where('active = 1')
-            ->where('deleted = 0')
-            ->select('id_reference, id_carrier')
-            ->limit(2);
-        $carriers = Db::getInstance()->executeS($query);
-
-        if (empty($carriers)) {
-            return false;
-        }
-
-        $this->assertEquals(2, count($carriers));
-        //Remove existing product-carrier associations
-        Db::getInstance()->delete('product_carrier', 'id_product in (1, 8)');
-        //Add the new product-carrier associations
-        $insertData = [
-            [
-                'id_product' => 1,
-                'id_carrier_reference' => $carriers[0]['id_reference'],
-                'id_shop' => 1,
-            ],
-            [
-                'id_product' => 8,
-                'id_carrier_reference' => $carriers[1]['id_reference'],
-                'id_shop' => 1,
-            ],
-        ];
-
-        $isDifferentCarriersSet = Db::getInstance()->insert('product_carrier', $insertData, false, true, Db::REPLACE);
-        $this->assertTrue($isDifferentCarriersSet);
-
-        $country = new \Country(\Country::getByIso('fr'));
-        $insertData = [
-            [
-                'id_carrier' => $carriers[0]['id_carrier'],
-                'id_zone' => $country->id_zone,
-            ],
-            [
-                'id_carrier' => $carriers[1]['id_carrier'],
-                'id_zone' => $country->id_zone,
-            ],
-        ];
-        $isCarrierZoneSet = Db::getInstance()->insert('carrier_zone', $insertData, false, true, Db::REPLACE);
-        $this->assertTrue($isCarrierZoneSet);
-    }
-
-    /**
-     * @depends testSetDifferentCarrierForProducts
-     */
     public function testImportSplittedOrder()
     {
         \Cache::clear();

--- a/202/tests/OrderImport/OrderSplittingTest.php
+++ b/202/tests/OrderImport/OrderSplittingTest.php
@@ -83,6 +83,7 @@ class OrderSplittingTest extends AbstractOrdeTestCase
      */
     public function testImportSplittedOrder()
     {
+        \Cache::clear();
         $apiOrder = $this->getOrderRessourceFromDataset('order-for-splitting.json');
 
         $handler = new ActionsHandler();

--- a/202/tests/OrderImport/dataset/order-for-splitting.json
+++ b/202/tests/OrderImport/dataset/order-for-splitting.json
@@ -57,12 +57,12 @@
           "image":"http://localhost/img/p/1/1-small_default.jpg"
        },
         {
-          "reference":"1_11",
+          "reference":"1_2",
           "status":"",
           "quantity":1,
           "price":10,
           "taxAmount":0,
-          "channelReference":"123",
+          "channelReference":"2",
           "name":"Sac à langer Biscuit",
           "image":"https://localhost/5465-large_default/sac-a-langer-biscuit-pasito-a-pasito.jpg"
         }
@@ -74,7 +74,7 @@
        "currency":"EUR",
        "method":"Paypal"
     },
-    "reference":"TEST-ORDER-AMAZON",
+    "reference":"TEST-ORDER-SPLITTING",
     "shipment":{
        "carrier":"Colissimo",
        "trackingNumber":""

--- a/202/tests/OrderImport/dataset/order-for-splitting.json
+++ b/202/tests/OrderImport/dataset/order-for-splitting.json
@@ -15,7 +15,7 @@
    },
    "_links":{
       "self":{
-         "href":"/v1/store/29573/order/6290304940"
+         "href":"/v1/store/29573/order/6290304940123"
       },
       "store":{
          "href":"/v1/store/29573"
@@ -42,7 +42,7 @@
    "errors":[
 
    ],
-   "id":6290304940,
+   "id":6290304940123,
    "isTest":true,
     "itemsReferencesAliases":null,
     "items":[

--- a/202/tests/OrderImport/dataset/order-for-splitting.json
+++ b/202/tests/OrderImport/dataset/order-for-splitting.json
@@ -1,0 +1,103 @@
+{
+   "_embedded":{
+      "channel":{
+         "_links":{
+            "image":{
+               "href":"https://assets.shopping-feed.com/channel/logo/.png"
+            },
+            "self":{
+               "href":"/v1/channel/66"
+            }
+         },
+         "id":66,
+         "name":"Amazon"
+      }
+   },
+   "_links":{
+      "self":{
+         "href":"/v1/store/29573/order/6290304940"
+      },
+      "store":{
+         "href":"/v1/store/29573"
+      }
+   },
+   "acknowledgedAt":null,
+   "additionalFields":null,
+   "billingAddress":{
+       "firstName":"",
+       "lastName":"Bernard Martin",
+       "company":"202 ecommerce",
+       "street":"10 rue Vivienne",
+       "street2":"",
+       "other":"",
+       "postalCode":"75002",
+       "city":"Paris",
+       "country":"FR",
+       "phone":"0123456789",
+       "mobilePhone":"0623456789",
+       "email":"unique.id@test.net"
+   },
+   "channelId":66,
+   "createdAt":"2022-02-01T00:00:00+01:00",
+   "errors":[
+
+   ],
+   "id":6290304940,
+   "isTest":true,
+    "itemsReferencesAliases":null,
+    "items":[
+       {
+          "reference":"8",
+          "status":"",
+          "quantity":1,
+          "price":4.5,
+          "taxAmount":0,
+          "channelReference":"2201DBFVY-MP002320-A-1",
+          "name":"Mug Today is a good day",
+          "image":"http://localhost/img/p/1/1-small_default.jpg"
+       },
+        {
+          "reference":"1_11",
+          "status":"",
+          "quantity":1,
+          "price":10,
+          "taxAmount":0,
+          "channelReference":"123",
+          "name":"Sac à langer Biscuit",
+          "image":"https://localhost/5465-large_default/sac-a-langer-biscuit-pasito-a-pasito.jpg"
+        }
+    ],
+    "payment":{
+       "shippingAmount":4.9,
+       "productAmount":14.5,
+       "totalAmount":19.4,
+       "currency":"EUR",
+       "method":"Paypal"
+    },
+    "reference":"TEST-ORDER-AMAZON",
+    "shipment":{
+       "carrier":"Colissimo",
+       "trackingNumber":""
+    },
+    "errors":[
+
+    ],
+   "shippingAddress":{
+       "firstName":"",
+       "lastName":"Bernard Martin",
+       "company":"202 ecommerce",
+       "street":"10 rue Vivienne",
+       "street2":"",
+       "other":"",
+       "postalCode":"75002",
+       "city":"Paris",
+       "country":"FR",
+       "phone":"0123456789",
+       "mobilePhone":"0623456789",
+       "email":"unique.id@test.net"
+   },
+   "status":"waiting_shipment",
+   "storeId":25125,
+   "storeReference":"",
+   "updatedAt":"2019-12-12T09:39:10+01:00"
+}

--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -916,7 +916,7 @@ class ShoppingfeedOrderImportActions extends DefaultActions
         $cart = new Cart($psOrder->id_cart);
 
         if ($cart->getNbOfPackages() > 1) {
-            if(Registry::isRegistered('order_for_cart_' . $cart->id)) {
+            if (Registry::isRegistered('order_for_cart_' . $cart->id)) {
                 $isResetShipping = true;
             } else {
                 Registry::set('order_for_cart_' . $cart->id, true);

--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1078,7 +1078,14 @@ class ShoppingfeedOrderImportActions extends DefaultActions
                 'id_carrier' => $carrier->id,
             ];
 
-            Db::getInstance()->update('orders', $updateOrder, '`id_order` = ' . (int) $id_order);
+            $psOrderObj = new Order((int) $id_order);
+
+            foreach ($updateOrder as $key => $value) {
+                $psOrderObj->{$key} = $value;
+            }
+
+            $psOrderObj->save(true);
+
             Db::getInstance()->update('order_invoice', $updateOrderInvoice, '`id_order` = ' . (int) $id_order);
             Db::getInstance()->update('order_carrier', $updateOrderTracking, '`id_order` = ' . (int) $id_order);
             Db::getInstance()->delete('order_cart_rule', 'id_order = ' . (int) $id_order);

--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1078,13 +1078,10 @@ class ShoppingfeedOrderImportActions extends DefaultActions
                 'id_carrier' => $carrier->id,
             ];
 
-            foreach ($updateOrder as $key => $value) {
-                $psOrder->{$key} = $value;
-            }
-            $psOrder->save(true);
+            Db::getInstance()->update('orders', $updateOrder, '`id_order` = ' . (int) $id_order);
             Db::getInstance()->update('order_invoice', $updateOrderInvoice, '`id_order` = ' . (int) $id_order);
             Db::getInstance()->update('order_carrier', $updateOrderTracking, '`id_order` = ' . (int) $id_order);
-            Db::getInstance()->delete('order_cart_rule', 'id_order = ' . $psOrder->id);
+            Db::getInstance()->delete('order_cart_rule', 'id_order = ' . (int) $id_order);
         }
 
         $queryUpdateOrderPayment = sprintf(

--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1078,13 +1078,18 @@ class ShoppingfeedOrderImportActions extends DefaultActions
                 'id_carrier' => $carrier->id,
             ];
 
-            $psOrderObj = new Order((int) $id_order);
-
-            foreach ($updateOrder as $key => $value) {
-                $psOrderObj->{$key} = $value;
+            if ($psOrder->id == $id_order) {
+                $orderObj = $psOrder;
+            } else {
+                $orderObj = new Order($id_order);
             }
 
-            $psOrderObj->save(true);
+
+            foreach ($updateOrder as $key => $value) {
+                $orderObj->{$key} = $value;
+            }
+
+            $orderObj->save(true);
 
             Db::getInstance()->update('order_invoice', $updateOrderInvoice, '`id_order` = ' . (int) $id_order);
             Db::getInstance()->update('order_carrier', $updateOrderTracking, '`id_order` = ' . (int) $id_order);
@@ -1102,7 +1107,7 @@ class ShoppingfeedOrderImportActions extends DefaultActions
             _DB_PREFIX_ . 'orders',
             _DB_PREFIX_ . 'order_payment',
             Tools::ps_round($paymentInformation['totalAmount'], 4),
-            (int) $id_order
+            (int) $psOrder->id
         );
         Db::getInstance()->execute($queryUpdateOrderPayment);
         Cache::clean('order_invoice_paid_*');

--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1084,7 +1084,6 @@ class ShoppingfeedOrderImportActions extends DefaultActions
                 $orderObj = new Order($id_order);
             }
 
-
             foreach ($updateOrder as $key => $value) {
                 $orderObj->{$key} = $value;
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In case of splitted order due to specific carriers set on each items of an order, the summary of each order is not OK.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 33703
| How to test?  | Tested by Unit Test