### PR TITLE
Regression during upgrade 1.7 to 1.8: class Hook not found

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -388,8 +388,13 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
             ];
         }
 
-        $this->hookDispatcher = new \ShoppingfeedAddon\Hook\HookDispatcher($this);
-        $this->hooks = array_merge($this->hooks, $this->hookDispatcher->getAvailableHooks());
+        // There is a risk having a class not found exception because of cache of autoload.php
+        try {
+            $this->hookDispatcher = new \ShoppingfeedAddon\Hook\HookDispatcher($this);
+            $this->hooks = array_merge($this->hooks, $this->hookDispatcher->getAvailableHooks());
+        } catch (Exception $e) { //for php version < 7.0
+        } catch (Throwable $e) {
+        }
 
         if ((int) Configuration::getGlobalValue(self::NEED_UPDATE_HOOK) === 1) {
             Configuration::updateGlobalValue(self::NEED_UPDATE_HOOK, (int) $this->updateHooks());

--- a/upgrade/install-1.8.0.php
+++ b/upgrade/install-1.8.0.php
@@ -21,15 +21,7 @@ function upgrade_module_1_8_0($module)
     $installer = new \ShoppingfeedClasslib\Install\ModuleInstaller($module);
     $installer->installObjectModel(ShoppingfeedPreloading::class);
     $installer->installObjectModel(ShoppingfeedOrder::class);
-
-    try {
-        $installer->registerHooks();
-    } catch (Exception $e) { //for php version < 7.0
-        Configuration::updateGlobalValue(Shoppingfeed::NEED_UPDATE_HOOK, 1);
-    } catch (Throwable $e) {
-        Configuration::updateGlobalValue(Shoppingfeed::NEED_UPDATE_HOOK, 1);
-    }
-
+    Configuration::updateGlobalValue(Shoppingfeed::NEED_UPDATE_HOOK, 1);
     $sql = 'UPDATE `' . _DB_PREFIX_ . ShoppingfeedPreloading::$definition['table'] . '` SET etag = md5(CONCAT(CURRENT_DATE, content))';
     Db::getInstance()->execute($sql);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix regression during upgrade 1.7 to 1.8 of this module.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #35437
| How to test?  | Try to upgrade from 1.7 to 1.8