### PR TITLE
refs #35398 - fix carrier retrieval after rules import

### DIFF
--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -225,12 +225,10 @@ class ShoppingfeedOrderImportActions extends DefaultActions
             $apiOrderShipment['carrier']
         );
 
-        if (Validate::isLoadedObject($sfCarrier)) {
-            $carrier = Carrier::getCarrierByReference($sfCarrier->id_carrier_reference);
-        }
-
         if (Validate::isLoadedObject($carrier) == false) {
-            $carrier = $this->initCarrierFinder()->getCarrierForOrderImport($apiOrder);
+            $channelName = $apiOrder->getChannel()->getName() ? $apiOrder->getChannel()->getName() : '';
+            $apiCarrierName = empty($apiOrderShipment['carrier'])? $apiOrder->getShipment()['carrier'] : $apiOrderShipment['carrier'];
+            $carrier = $this->initCarrierFinder()->getCarrierForOrderImport($channelName, $apiCarrierName);
         }
 
         if (!Validate::isLoadedObject($carrier)) {

--- a/src/OrderImport/Rules/ManomanoDpdRelais.php
+++ b/src/OrderImport/Rules/ManomanoDpdRelais.php
@@ -194,7 +194,9 @@ class ManomanoDpdRelais extends RuleAbstract implements RuleInterface
 
     protected function isDpdCarrier(OrderResource $apiOrder)
     {
-        $carrier = $this->initCarrierFinder()->getCarrierForOrderImport($apiOrder);
+        $channelName = $apiOrder->getChannel()->getName() ? $apiOrder->getChannel()->getName() : '';
+        $apiCarrierName = empty($apiOrder->getShipment()['carrier']) ? '' : $apiOrder->getShipment()['carrier'];
+        $carrier = $this->initCarrierFinder()->getCarrierForOrderImport($channelName, $apiCarrierName);
 
         if (false == Validate::isLoadedObject($carrier)) {
             return false;

--- a/src/Services/CarrierFinder.php
+++ b/src/Services/CarrierFinder.php
@@ -65,12 +65,9 @@ class CarrierFinder
         return $carrier;
     }
 
-    public function getCarrierForOrderImport(OrderResource $apiOrder)
+    public function getCarrierForOrderImport($channelName, $apiCarrierName)
     {
         $carrier = null;
-        $channelName = $apiOrder->getChannel()->getName() ? $apiOrder->getChannel()->getName() : '';
-        $apiCarrierName = empty($apiOrder->getShipment()['carrier']) ? '' : $apiOrder->getShipment()['carrier'];
-
         $sfCarrier = ShoppingfeedCarrier::getByMarketplaceAndName(
             $channelName,
             $apiCarrierName


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | load wrong carrier after carrier name is update by rule MissingCarrier 
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #35398.
| How to test?  |  

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
