### PR TITLE
Add ecotax value on product's variations

### DIFF
--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -157,7 +157,7 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
                 ->setReference($variation['reference'])
                 ->setPrice($variation['price'])
             ;
-            if (isset($variation['ecotax'])) {
+            if (isset($variation['ecotax']) && $this->isEcotaxEnabled()) {
                 $variationProduct->setEcotax($variation['ecotax']);
             }
             if (isset($variation['quantity']) === true) {
@@ -288,5 +288,10 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
         }
 
         return 0;
+    }
+
+    protected function isEcotaxEnabled()
+    {
+        return (bool) Configuration::get('PS_USE_ECOTAX');
     }
 }

--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -157,6 +157,9 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
                 ->setReference($variation['reference'])
                 ->setPrice($variation['price'])
             ;
+            if (isset($variation['ecotax'])) {
+                $variationProduct->setEcotax($variation['ecotax']);
+            }
             if (isset($variation['quantity']) === true) {
                 $variationProduct->setQuantity($variation['quantity']);
             }

--- a/src/Services/ProductAttributeCombination.php
+++ b/src/Services/ProductAttributeCombination.php
@@ -113,6 +113,7 @@ class ProductAttributeCombination
                 $combinations[$idProductAttribute]['weight'] = $row['weight'];
                 $combinations[$idProductAttribute]['reference'] = $row['reference'];
                 $combinations[$idProductAttribute]['wholesale_price'] = $row['wholesale_price'];
+                $combinations[$idProductAttribute]['ecotax'] = $row['ecotax'];
             }
 
             $combinations[$idProductAttribute]['attributes'][$row['group_name']] = $row['attribute_name'];

--- a/src/Services/ProductSerializer.php
+++ b/src/Services/ProductSerializer.php
@@ -405,6 +405,7 @@ class ProductSerializer
                 'attributes' => [
                     'hierararchy' => 'child',
                 ],
+                'ecotax' => $combination['ecotax'],
             ];
 
             if (empty($combination['ean13']) === false) {

--- a/vendor/shoppingfeed/php-feed-generator/src/Product/AbstractProduct.php
+++ b/vendor/shoppingfeed/php-feed-generator/src/Product/AbstractProduct.php
@@ -54,6 +54,11 @@ abstract class AbstractProduct
     private $additionalImages = [];
 
     /**
+     * @var float
+     */
+    private $ecotax = .0;
+
+    /**
      * @return string
      */
     public function getReference()
@@ -334,5 +339,25 @@ abstract class AbstractProduct
     public function isValid()
     {
         return $this->reference && isset($this->price);
+    }
+
+    /**
+     * @return float
+     */
+    public function getEcotax()
+    {
+        return $this->ecotax;
+    }
+
+    /**
+     * @param float $ecotax
+     *
+     * @return $this
+     */
+    public function setEcotax($ecotax)
+    {
+        $this->ecotax = \ShoppingFeed\Feed\price_format($ecotax);
+
+        return $this;
     }
 }

--- a/vendor/shoppingfeed/php-feed-generator/src/Product/Product.php
+++ b/vendor/shoppingfeed/php-feed-generator/src/Product/Product.php
@@ -36,11 +36,6 @@ final class Product extends AbstractProduct
     /**
      * @var float
      */
-    private $ecotax = .0;
-
-    /**
-     * @var float
-     */
     private $vat = .0;
 
     /**
@@ -212,25 +207,6 @@ final class Product extends AbstractProduct
         }
 
         return false;
-    }
-    /**
-     * @return float
-     */
-    public function getEcotax()
-    {
-        return $this->ecotax;
-    }
-
-    /**
-     * @param float $ecotax
-     *
-     * @return $this
-     */
-    public function setEcotax($ecotax)
-    {
-        $this->ecotax = \ShoppingFeed\Feed\price_format($ecotax);
-
-        return $this;
     }
 
     /**

--- a/vendor/shoppingfeed/php-feed-generator/src/Xml/XmlProductFeedWriter.php
+++ b/vendor/shoppingfeed/php-feed-generator/src/Xml/XmlProductFeedWriter.php
@@ -134,6 +134,10 @@ class XmlProductFeedWriter implements Feed\ProductFeedWriterInterface
         $this->writeElement('reference', $product->getReference());
         $this->writeElement('quantity', $product->getQuantity());
         $this->writeElement('price', $product->getPrice());
+
+        if ($ecotax = $product->getEcotax()) {
+            $this->writeElement('ecotax', $ecotax);
+        }
         if ($link = $product->getLink()) {
             $this->writeCdataElement('link', $link);
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add ecotax value on product's variations if general setting PS_ECOTAX is enabled
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #35844
| How to test?  | Enable Ecotax on PrestaShop, add an ecotax on a product with  declinaison. All variations on the product XML feed should have a node with ecotax.
