### PR TITLE
refs #36123 order configuration are not saved

### DIFF
--- a/controllers/admin/AdminShoppingfeedOrderImportRules.php
+++ b/controllers/admin/AdminShoppingfeedOrderImportRules.php
@@ -483,6 +483,8 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
                     'submit' => [
                         'title' => $this->module->l('Save', 'AdminShoppingfeedOrderImportRules'),
                         'name' => 'saveOrdersConfig',
+                        // PS hides the button if this is not set
+                        'id' => 'shoppingfeed_saveOrderSync-submit',
                     ],
                 ],
             ],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | regression. Save order settings not available 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 36123
| How to test?  | try to save order settings in the module.