### PR TITLE
Fixies on php 7.0- and PS 1.6

### DIFF
--- a/controllers/admin/AdminShoppingfeedDiagnostic.php
+++ b/controllers/admin/AdminShoppingfeedDiagnostic.php
@@ -23,6 +23,11 @@
  *
  * @version   release/2.3.2
  */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once _PS_MODULE_DIR_ . 'shoppingfeed/vendor/autoload.php';
 
 use ShoppingfeedClasslib\Extensions\Diagnostic\Controllers\Admin\AdminDiagnosticController;
 

--- a/src/OrderImport/Rules/AbstractMondialrelay.php
+++ b/src/OrderImport/Rules/AbstractMondialrelay.php
@@ -367,8 +367,4 @@ abstract class AbstractMondialrelay extends RuleAbstract implements RuleInterfac
     }
 
     abstract public function getRelayId($orderData);
-
-    abstract public function getConditions();
-
-    abstract public function getDescription();
 }

--- a/vendor/totpsclasslib/src/Extensions/Diagnostic/Stubs/Handler/LogsStubHandler.php
+++ b/vendor/totpsclasslib/src/Extensions/Diagnostic/Stubs/Handler/LogsStubHandler.php
@@ -36,13 +36,13 @@ class LogsStubHandler extends AbstractStubHandler
 {
     use TranslateTrait;
 
-    private const LIMITE_DB_NUMBER_OF_DAYS = 30;
+    const LIMITE_DB_NUMBER_OF_DAYS = 30;
 
-    private const LIMITE_DB_RAWS_ON_SCREEN = 100;
+    const LIMITE_DB_RAWS_ON_SCREEN = 100;
 
-    private const LIMITE_FILE_RAWS_ON_SCREEN = 100;
+    const LIMITE_FILE_RAWS_ON_SCREEN = 100;
 
-    private const LIMITE_SIZE_FILE = 2*1000000;
+    const LIMITE_SIZE_FILE = 2*1000000;
 
     public function handle()
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | AbstractMondialRelay bloque AdminShoppingfeedOrderImportRulesController<br>Diagnostic Tab is KO due to 500 error
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 36360
| How to test?  | View support on 1.6.1.5 PHP 7.0