### PR TITLE
refs #36621 - fix error when get product feed rule filters

### DIFF
--- a/controllers/admin/AdminShoppingfeedGeneralSettings.php
+++ b/controllers/admin/AdminShoppingfeedGeneralSettings.php
@@ -564,6 +564,9 @@ class AdminShoppingfeedGeneralSettingsController extends ShoppingfeedAdminContro
     protected function getProductFilters()
     {
         $product_feed_rule_filters = Configuration::getGlobalValue(Shoppingfeed::PRODUCT_FEED_RULE_FILTERS);
+        if ($product_feed_rule_filters === false) {
+            return [];
+        }
         $product_feed_rule_filters = Tools::jsonDecode($product_feed_rule_filters, true);
         $product_filters = [];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #36621
| How to test?  | enable debug mode and go to  "Products feed" tab

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
