### PR TITLE
catch warning during the order import in case of missing product translations (37365)

### DIFF
--- a/src/Hook/ActionShoppingfeedTracking/RelaisColis.php
+++ b/src/Hook/ActionShoppingfeedTracking/RelaisColis.php
@@ -68,9 +68,7 @@ class RelaisColis extends AbstractHook
     {
         try {
             return new RelaisColisOrder($this->getIdRelaisColisOrderFromPsOrder($order));
-        } catch (\Exception $e) {
-            return null;
-        } catch (\Throwable $e) {// Throwable exists from php 7
+        } catch (\Throwable $e) {
             return null;
         }
     }
@@ -79,9 +77,7 @@ class RelaisColis extends AbstractHook
     {
         try {
             return (int) RelaisColisOrder::getRelaisColisOrderId($order->id);
-        } catch (\Exception $e) {
-            return null;
-        } catch (\Throwable $e) {// Throwable exists from php 7
+        } catch (\Throwable $e) {
             return null;
         }
     }

--- a/src/OrderImport/Rules/RelaisColisRule.php
+++ b/src/OrderImport/Rules/RelaisColisRule.php
@@ -32,7 +32,6 @@ use Address;
 use Cart;
 use Configuration;
 use Country;
-use Exception;
 use Module;
 use Order;
 use ShoppingFeed\Sdk\Api\Order\OrderResource;
@@ -230,7 +229,7 @@ class RelaisColisRule extends RuleAbstract implements RuleInterface
 
         try {
             $relaisColisInfo->save();
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return new \RelaisColisInfo();
         }
 

--- a/src/OrderImport/Rules/ShippedByMarketplace.php
+++ b/src/OrderImport/Rules/ShippedByMarketplace.php
@@ -29,7 +29,6 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use Configuration;
-use Exception;
 use Order;
 use OrderHistory;
 use OrderState;
@@ -231,7 +230,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         try {
             return strpos(strtolower($apiOrder->getPaymentInformation()['method']), 'afn') !== false;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }
@@ -245,7 +244,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         try {
             return strpos(strtolower($apiOrder->getPaymentInformation()['method']), 'clogistique') !== false;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }
@@ -259,7 +258,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         try {
             return strtolower($apiOrder->toArray()['additionalFields']['env']) == 'epmm';
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | catch warning during the order import in case of missing product translations
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 37365
| How to test?  | Due to data integrity of the merchand... not testable