### PR TITLE
refs#36642 - add default phone mobile for order with colissimo

### DIFF
--- a/src/OrderImport/Rules/AbstractColissimo.php
+++ b/src/OrderImport/Rules/AbstractColissimo.php
@@ -58,6 +58,16 @@ abstract class AbstractColissimo extends RuleAbstract implements RuleInterface
         }
     }
 
+    public function beforeBillingAddressSave($params)
+    {
+        $this->setDefaultPhoneMobile($params['billingAddress']->phone_mobile);
+    }
+
+    public function beforeShippingAddressSave($params)
+    {
+        $this->setDefaultPhoneMobile($params['shippingAddress']->phone_mobile);
+    }
+
     public function afterCartCreation($params)
     {
         if (class_exists(ColissimoPickupPoint::class) === false || class_exists(ColissimoCartPickupPoint::class) === false) {
@@ -149,4 +159,11 @@ abstract class AbstractColissimo extends RuleAbstract implements RuleInterface
     abstract protected function getProductCode(OrderResource $apiOrder);
 
     abstract protected function getPointId(OrderResource $apiOrder);
+
+    private function setDefaultPhoneMobile(&$phone_mobile)
+    {
+        if (empty($phone_mobile) || Validate::isPhoneNumber($phone_mobile) === false) {
+            $phone_mobile = '0611111111';
+        }
+    }
 }

--- a/src/OrderImport/Rules/AbstractColissimo.php
+++ b/src/OrderImport/Rules/AbstractColissimo.php
@@ -58,11 +58,6 @@ abstract class AbstractColissimo extends RuleAbstract implements RuleInterface
         }
     }
 
-    public function beforeBillingAddressSave($params)
-    {
-        $this->setDefaultPhoneMobile($params['billingAddress']->phone_mobile);
-    }
-
     public function beforeShippingAddressSave($params)
     {
         $this->setDefaultPhoneMobile($params['shippingAddress']->phone_mobile);
@@ -160,7 +155,7 @@ abstract class AbstractColissimo extends RuleAbstract implements RuleInterface
 
     abstract protected function getPointId(OrderResource $apiOrder);
 
-    private function setDefaultPhoneMobile(&$phone_mobile)
+    protected function setDefaultPhoneMobile(&$phone_mobile)
     {
         if (empty($phone_mobile) || Validate::isPhoneNumber($phone_mobile) === false) {
             $phone_mobile = '0611111111';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Padd default phone mobile for order with colissimo.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #36642
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
