### PR TITLE
Fixbug: remove a discount from invoice (37710)

### DIFF
--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1085,6 +1085,8 @@ class ShoppingfeedOrderImportActions extends DefaultActions
                 'total_products_wt' => Tools::ps_round($orderPrices['total_products_tax_incl'], 2),
                 'total_shipping_tax_incl' => Tools::ps_round($orderPrices['total_shipping_tax_incl'], 2),
                 'total_shipping_tax_excl' => Tools::ps_round($orderPrices['total_shipping_tax_excl'], 4),
+                'total_discount_tax_excl' => 0,
+                'total_discount_tax_incl' => 0,
             ];
 
             $updateOrderTracking = [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | remove a discount from invoice. It seems the problem arrives when the PS generates an order invoice before the module recalculates the prices (hook actionValidateOrder). 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 37710
| How to test?  | unit tested