### PR TITLE
Add token as mandatory to get product xml feed (37103)

### DIFF
--- a/controllers/admin/AdminShoppingfeedGeneralSettings.php
+++ b/controllers/admin/AdminShoppingfeedGeneralSettings.php
@@ -104,7 +104,15 @@ class AdminShoppingfeedGeneralSettingsController extends ShoppingfeedAdminContro
         $this->context->smarty->assign('count_products', $this->nbr_products);
         $this->context->smarty->assign('hasAFilter', $product_filters !== null);
         $this->context->smarty->assign('percent_preloading', floor($percentPreloading));
-
+        $this->context->smarty->assign(
+            'productFlowLink',
+            $this->context->link->getModuleLink(
+                'shoppingfeed',
+                'product',
+                ['token' => empty($token['content']) ? '' : $token['content']],
+                true
+            )
+        );
         $crons = new ShoppingfeedClasslib\Extensions\ProcessMonitor\Classes\ProcessMonitorObjectModel();
         $syncProduct = $crons->findOneByName('shoppingfeed:syncProduct');
         $this->context->smarty->assign('syncProduct', $syncProduct);

--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -37,7 +37,7 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
 
     public function viewAccess()
     {
-        if (false == empty($this->sfToken)) {
+        if (empty($this->sfToken)) {
             header('HTTP/1.1 401 Unauthorized');
             exit;
         }

--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -38,7 +38,7 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
     public function checkAccess()
     {
         if (empty($this->sfToken)) {
-            header('HTTP/1.1 401 Unauthorized');
+            http_response_code(401);
             exit;
         }
 

--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -35,7 +35,7 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
         $this->sfToken = (new ShoppingfeedToken())->findByToken(Tools::getValue('token', ''));
     }
 
-    public function viewAccess()
+    public function checkAccess()
     {
         if (empty($this->sfToken)) {
             header('HTTP/1.1 401 Unauthorized');

--- a/views/templates/admin/shoppingfeed_general_settings/products_feeds.tpl
+++ b/views/templates/admin/shoppingfeed_general_settings/products_feeds.tpl
@@ -36,7 +36,7 @@
             </a>
         </div>
         <div class="col-sm-6 col-lg-4">
-            <a href="{$link->getModuleLink('shoppingfeed', 'product')|escape:'html':'UTF-8'}" id="box-products-stock" data-toggle="tooltip" class="box-stats label-tooltip color1" data-original-title="{l s='Disabled products are not in the feed.' mod='shoppingfeed'}">
+            <a href="{$productFlowLink|escape:'html':'UTF-8'}" id="box-products-stock" data-toggle="tooltip" class="box-stats label-tooltip color1" data-original-title="{l s='Disabled products are not in the feed.' mod='shoppingfeed'}">
                 <div class="kpi-content">
                     <i class="icon-archive"></i>
                     <span class="title">{l s='Exported products' mod='shoppingfeed'}</span>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | get product feed under token only
| Type?         | bug fix
| BC breaks?    | yes, url without token return now 401
| Deprecations? | no
| Fixed ticket? | Fixes 37103
| How to test?  | visit the url of product feed with and without token