### PR TITLE
Order shipped by marketplace imported in error (38044)

### DIFF
--- a/202/tests/OrderImport/OrderShippedByMarketplaceTest.php
+++ b/202/tests/OrderImport/OrderShippedByMarketplaceTest.php
@@ -31,7 +31,7 @@ class OrderShippedByMarketplaceTest extends AbstractOrdeTestCase
     {
         $apiOrder = $this->getOrderRessourceFromDataset('order-shipped-afn.json');
         $rule = new ShippedByMarketplace([
-            \Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE => false
+            \Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE => false,
         ]);
 
         $this->assertTrue($rule->isApplicable($apiOrder));

--- a/202/tests/OrderImport/OrderShippedByMarketplaceTest.php
+++ b/202/tests/OrderImport/OrderShippedByMarketplaceTest.php
@@ -21,11 +21,29 @@ namespace Tests\OrderImport;
 
 use Order;
 use ShoppingfeedAddon\Actions\ActionsHandler;
+use ShoppingfeedAddon\OrderImport\Rules\ShippedByMarketplace;
 use ShoppingfeedClasslib\Registry;
 use StockAvailable;
 
 class OrderShippedByMarketplaceTest extends AbstractOrdeTestCase
 {
+    public function testOrderSkipping()
+    {
+        $apiOrder = $this->getOrderRessourceFromDataset('order-shipped-afn.json');
+        $rule = new ShippedByMarketplace([
+            \Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE => false
+        ]);
+
+        $this->assertTrue($rule->isApplicable($apiOrder));
+
+        $params = [
+            'isSkipImport' => false,
+            'apiOrder' => $apiOrder,
+        ];
+        $rule->onVerifyOrder($params);
+        $this->assertTrue($params['isSkipImport']);
+    }
+
     public function testImportAfn()
     {
         $apiOrder = $this->getOrderRessourceFromDataset('order-shipped-afn.json');

--- a/src/OrderImport/RuleAbstract.php
+++ b/src/OrderImport/RuleAbstract.php
@@ -40,10 +40,7 @@ abstract class RuleAbstract implements RuleInterface
      */
     public function __construct($configuration = [])
     {
-        if (empty($configuration)) {
-            $configuration = $this->getDefaultConfiguration();
-        }
-        $this->configuration = $configuration;
+        $this->configuration = array_merge($this->getDefaultConfiguration(), $configuration);
     }
 
     /**

--- a/src/OrderImport/Rules/ShippedByMarketplace.php
+++ b/src/OrderImport/Rules/ShippedByMarketplace.php
@@ -56,15 +56,15 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
         return false;
     }
 
-    public function onVerifyOrder($params)
+    public function onVerifyOrder(&$params)
     {
         $apiOrder = $params['apiOrder'];
         if ($this->isShippedByMarketplace($apiOrder)) {
-            if (Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE) === false) {
+            if (Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE) == false) {
                 $this->logSkipImport($apiOrder);
                 $params['isSkipImport'] = true;
             }
-        } elseif ($apiOrder->getStatus() == 'shipped' && Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED) === false) {
+        } elseif ($apiOrder->getStatus() === 'shipped' && Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED) == false) {
             $this->logSkipImport($apiOrder);
             $params['isSkipImport'] = true;
         }

--- a/src/OrderImport/Rules/ShippedByMarketplace.php
+++ b/src/OrderImport/Rules/ShippedByMarketplace.php
@@ -60,11 +60,11 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         $apiOrder = $params['apiOrder'];
         if ($this->isShippedByMarketplace($apiOrder)) {
-            if (Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE) == false) {
+            if ($this->configuration[\Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE] == false) {
                 $this->logSkipImport($apiOrder);
                 $params['isSkipImport'] = true;
             }
-        } elseif ($apiOrder->getStatus() === 'shipped' && Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED) == false) {
+        } elseif ($apiOrder->getStatus() === 'shipped' && $this->configuration[\Shoppingfeed::ORDER_IMPORT_SHIPPED] == false) {
             $this->logSkipImport($apiOrder);
             $params['isSkipImport'] = true;
         }
@@ -149,7 +149,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
         if (empty($this->configuration['end_order_state_shipped']) === false) {
             $changeStateId = $this->configuration['end_order_state_shipped'];
         } else {
-            $changeStateId = (int) Configuration::get('PS_OS_DELIVERED');
+            $changeStateId = (int) $this->configuration['PS_OS_DELIVERED'];
         }
 
         if (false == $this->isOrderStateValid($changeStateId)) {
@@ -305,5 +305,14 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
             $logPrefix . $this->l('Rule triggered. Import should be skipped.', 'Shoppingfeed.Rule'),
             'Order'
         );
+    }
+
+    protected function getDefaultConfiguration()
+    {
+        return [
+            \Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE => Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED_MARKETPLACE),
+            \Shoppingfeed::ORDER_IMPORT_SHIPPED => Configuration::get(\Shoppingfeed::ORDER_IMPORT_SHIPPED),
+            'PS_OS_DELIVERED' => Configuration::get('PS_OS_DELIVERED'),
+        ];
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The merchant configuration of SF module is : import shipped status to YES, Import orders shipped by Market place to NO<br>Orders shipped by Market place are imported in error in logs.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 38044
| How to test?  | Unit tested