### PR TITLE
Add ecotax in product variation attributes (38070)

### DIFF
--- a/202/docker/run_for_unittest.sh
+++ b/202/docker/run_for_unittest.sh
@@ -13,7 +13,7 @@ php /var/www/html/bin/console prestashop:module install mondialrelay -e prod
 echo "Add data fixtures for Unit Tests"
 
 mysql -h localhost -u root prestashop -e "
-
+truncate ps_shoppingfeed_preloading;
 truncate ps_mondialrelay_carrier_method;
 INSERT INTO ps_mondialrelay_carrier_method (id_carrier, delivery_mode, insurance_level, is_deleted, id_reference, date_add, date_upd)
 VALUES ('1', '24R', '0', '0', '1', '2022-06-23 11:30:14', '2022-06-23 11:30:14');
@@ -27,6 +27,7 @@ INSERT INTO ps_configuration (id_shop_group, id_shop, name, value, date_add, dat
 (NULL, NULL, 'MONDIALRELAY_WEIGHT_COEFF', '1', now(), now());
 
 UPDATE ps_product_attribute SET reference = 'demo_17_white' WHERE id_product = 11 AND default_on = 1;
+UPDATE ps_product_attribute_shop SET ecotax = 6 WHERE id_product = 5 AND id_product_attribute = 19;;
 
 TRUNCATE ps_shoppingfeed_order;
 UPDATE ps_configuration SET value = '[\"5\",\"4\"]' WHERE name = 'SHOPPINGFEED_SHIPPED_ORDERS';

--- a/202/tests/ProductSerializer/TestAttributeTestCase.php
+++ b/202/tests/ProductSerializer/TestAttributeTestCase.php
@@ -187,6 +187,5 @@ class TestAttributeTestCase extends TestCase
         $this->assertArrayHasKey('attributes', $productContent['variations'][$id_product_attribute]);
         $this->assertArrayHasKey('ecotax_child', $productContent['variations'][$id_product_attribute]['attributes']);
         $this->assertEquals($productContent['variations'][$id_product_attribute]['attributes']['ecotax_child'], '6.000000');
-
     }
 }

--- a/202/tests/ProductSerializer/TestAttributeTestCase.php
+++ b/202/tests/ProductSerializer/TestAttributeTestCase.php
@@ -167,4 +167,26 @@ class TestAttributeTestCase extends TestCase
         $this->assertArrayHasKey('attributes', $productContent['variations'][$id_product_attribute]);
         $this->assertArrayNotHasKey('availability_label', $productContent['variations'][$id_product_attribute]['attributes']);
     }
+
+    public function testGetProductEcotaxChild()
+    {
+        $id_product = 5;
+        $id_product_attribute = 19;
+        $id_token = 1;
+        $handler = new ActionsHandler();
+        $handler->addActions('getBatch')
+                ->setConveyor(['id_token' => $id_token])
+                ->process('ShoppingfeedProductSyncPreloading');
+
+        $product = (new ShoppingfeedPreloading())->findByTokenIdAndProductId($id_token, $id_product);
+        $this->assertArrayHasKey('content', $product);
+        $productContent = json_decode($product['content'], true);
+        $this->assertIsArray($productContent);
+        $this->assertArrayHasKey('variations', $productContent);
+        $this->assertArrayHasKey($id_product_attribute, $productContent['variations']);
+        $this->assertArrayHasKey('attributes', $productContent['variations'][$id_product_attribute]);
+        $this->assertArrayHasKey('ecotax_child', $productContent['variations'][$id_product_attribute]['attributes']);
+        $this->assertEquals($productContent['variations'][$id_product_attribute]['attributes']['ecotax_child'], '6.000000');
+
+    }
 }

--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -165,12 +165,7 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
                 ->setReference($variation['reference'])
                 ->setPrice($variation['price'])
             ;
-            /**
-             * @todo: PR not accepted https://github.com/shoppingflux/php-feed-generator/pull/21
-            if (isset($variation['ecotax']) && $this->isEcotaxEnabled()) {
-                $variationProduct->setEcotax($variation['ecotax']);
-            }
-             */
+
             if (isset($variation['quantity']) === true) {
                 $variationProduct->setQuantity($variation['quantity']);
             }

--- a/src/Services/ProductAttributeCombination.php
+++ b/src/Services/ProductAttributeCombination.php
@@ -108,7 +108,6 @@ class ProductAttributeCombination
                 $combinations[$idProductAttribute]['weight'] = $row['weight'];
                 $combinations[$idProductAttribute]['reference'] = $row['reference'];
                 $combinations[$idProductAttribute]['wholesale_price'] = $row['wholesale_price'];
-                $combinations[$idProductAttribute]['ecotax'] = $row['ecotax'];
             }
 
             $combinations[$idProductAttribute]['attributes'][$row['group_name']] = $row['attribute_name'];

--- a/src/Services/ProductAttributeCombination.php
+++ b/src/Services/ProductAttributeCombination.php
@@ -108,6 +108,7 @@ class ProductAttributeCombination
                 $combinations[$idProductAttribute]['weight'] = $row['weight'];
                 $combinations[$idProductAttribute]['reference'] = $row['reference'];
                 $combinations[$idProductAttribute]['wholesale_price'] = $row['wholesale_price'];
+                $combinations[$idProductAttribute]['ecotax'] = $row['ecotax'];
             }
 
             $combinations[$idProductAttribute]['attributes'][$row['group_name']] = $row['attribute_name'];

--- a/src/Services/ProductSerializer.php
+++ b/src/Services/ProductSerializer.php
@@ -411,6 +411,11 @@ class ProductSerializer
             if (empty($combination['ean13']) === false) {
                 $variation['gtin'] = $combination['ean13'];
             }
+
+            if (empty($combination['ecotax']) === false) {
+                $variation['attributes']['ecotax_child'] = $combination['ecotax'];
+            }
+
             if (empty($combination['upc']) === false) {
                 $variation['attributes']['upc'] = $combination['upc'];
             }

--- a/src/Services/ProductSerializer.php
+++ b/src/Services/ProductSerializer.php
@@ -405,7 +405,6 @@ class ProductSerializer
                 'attributes' => [
                     'hierararchy' => 'child',
                 ],
-                'ecotax' => $combination['ecotax'],
             ];
 
             if (empty($combination['ean13']) === false) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | add ecotax in product variation attributes.
| Type?         | improvement
| BC breaks?    |no
| Deprecations? |no
| Fixed ticket? | Fixes #38070
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
