### PR TITLE
refs#38301 - fix prduct name for Zalando displayed on invoices

### DIFF
--- a/202/tests/OrderImport/OrderImportZalandoTest.php
+++ b/202/tests/OrderImport/OrderImportZalandoTest.php
@@ -119,8 +119,8 @@ class OrderImportZalandoTest extends AbstractOrdeTestCase
 
         $this->assertTrue(is_array($details));
         $this->assertTrue(count($details) === 2);
-        $this->assertEquals($details[0]['product_name'], 'Haut de maillot triangle maille crochet Dolce noir : 32632708-cc99-32d1-aa43-ca59521a9c9e - JR581J004-Q11009500D');
-        $this->assertEquals($details[1]['product_name'], 'Bas de maillot de bain brésilien en crochet à nouettes réglables Dolce noir : 0c6a3824-272a-3333-87bf-5a6962ad83b1 - JR581I00D-Q110042000');
+        $this->assertEquals($details[0]['product_name'], 'Hummingbird printed t-shirt (Size: S - Color: White) : 32632708-cc99-32d1-aa43-ca59521a9c9e - JR581J004-Q11009500D');
+        $this->assertEquals($details[1]['product_name'], 'Hummingbird printed t-shirt (Size: S - Color: Black) : 0c6a3824-272a-3333-87bf-5a6962ad83b1 - JR581I00D-Q110042000');
     }
 
     /**

--- a/src/OrderImport/Rules/Zalando.php
+++ b/src/OrderImport/Rules/Zalando.php
@@ -56,7 +56,7 @@ class Zalando extends RuleAbstract implements RuleInterface
             }
             $psProduct = $params['prestashopProducts'][$apiProduct['reference']];
             $query = new DbQuery();
-            $query->select('od.id_order_detail')
+            $query->select('od.id_order_detail, od.product_name')
                 ->from('order_detail', 'od')
                 ->where('od.id_order = ' . (int) $params['id_order'])
                 ->where('od.product_id = ' . (int) $psProduct->id)
@@ -67,14 +67,14 @@ class Zalando extends RuleAbstract implements RuleInterface
             $productOrderDetail = Db::getInstance()->getRow($query);
             $product_name = sprintf(
                 '%s : %s - %s',
-                substr($apiProduct['name'], 0, 188), // fix size name product to 250 maximum
+                substr($productOrderDetail['product_name'], 0, 188), // fix size name product to 250 maximum
                 $apiProduct['additionalFields']['order_item_id'],
                 $apiProduct['additionalFields']['article_id']
             );
 
             Db::getInstance()->update(
                 'order_detail',
-                ['product_name' => $product_name],
+                ['product_name' => pSQL($product_name)],
                 '`id_order_detail` = ' . (int) $productOrderDetail['id_order_detail']
             );
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | fix prduct name for Zalando displayed on invoices.
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #38301.
| How to test?  | Unit test OrderImportZalandoTest

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
