### PR TITLE
If order is already imported should be acknowledged (38385)

### DIFF
--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -122,6 +122,7 @@ class ShoppingfeedOrderImportActions extends DefaultActions
         if (ShoppingfeedOrder::existsInternalId($apiOrder->getId())) {
             $this->conveyor['error'] = $this->l('Order not imported; already present.', 'ShoppingfeedOrderImportActions');
             ProcessLoggerHandler::logInfo($this->logPrefix . $this->conveyor['error'], 'Order');
+            $this->conveyor['isSkipImport'] = true;
             $this->forward('acknowledgeOrder');
 
             return false;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If order is already imported should to acknowledge as successfully imported
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 38385
| How to test?  | Unit tested