### PR TITLE
fix upgrade in case of multirequests to alter table

### DIFF
--- a/vendor/totpsclasslib/src/Db/DbTable.php
+++ b/vendor/totpsclasslib/src/Db/DbTable.php
@@ -101,10 +101,16 @@ class DbTable
             return $result;
         }
         // table exists
-        $alter = $this->alterFields();
+        $alters = $this->alterFields();
 
-        if (!empty($alter)) {
-            return $this->db->execute($alter);
+        if (!empty($alters)) {
+            foreach ($alters as $alter) {
+                $result = $this->db->execute($alter);
+                if ($result === false) {
+                    return false;
+                }
+            }
+
         }
         $this->alterKeys();
 
@@ -128,7 +134,6 @@ class DbTable
                 $describe[$key]['modelDef'] .= Tools::strtoupper($col['Extra']);
             }
         }
-
         $alterToSkip = array();
         $alterToExecute = array();
         $alters = array();
@@ -138,16 +143,16 @@ class DbTable
                     $alterToSkip[$key] = true;
                 } elseif (false !== strpos($column, '`' . $col['Field'] . '`')) {
                     $alterToExecute[$key] = 'MODIFY';
-                    $alters[$key] = "ALTER TABLE `$this->name` MODIFY $column;";
+                    $alters[$key] = "ALTER TABLE `$this->name` MODIFY $column";
                 }
             }
             if (empty($alterToExecute[$key]) && empty($alterToSkip[$key])) {
                 $alterToExecute[$key]['action'] = 'ADD '.$column;
-                $alters[$key] =  "ALTER TABLE `$this->name` ADD $column;";
+                $alters[$key] =  "ALTER TABLE `$this->name` ADD $column";
             }
         }
 
-        return implode("\r\n", $alters);
+        return $alters;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PrestaShop forbid the multi sql request upgrade are broken. PS 1.7.8.8 and 8.0.1
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | nc
| How to test?  | Upgrade from 1.8.3 to 1.9.3 and check if additionalFields is adden on ps_shoppingfeed_order table
