### PR TITLE
xml tag has to locate at first line (40448)

### DIFF
--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -89,6 +89,7 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
 
         $limit = 100;
         $nb_iteration = ceil((new ShoppingfeedPreloading())->getPreloadingCount($this->sfToken['id_shoppingfeed_token']) / $limit);
+        ob_end_clean();
         $productGenerator->open();
 
         for ($i = 0; $i < $nb_iteration; ++$i) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | XML tag has to locate at first line otherwise an error occurs
| Type?         | bug fix 
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
