### PR TITLE
refs #40613 eligibility condition for a rule Zalando

### DIFF
--- a/src/OrderImport/Rules/Zalando.php
+++ b/src/OrderImport/Rules/Zalando.php
@@ -39,11 +39,11 @@ class Zalando extends RuleAbstract implements RuleInterface
         if (key_exists('channelId', $data) === false) {
             return false;
         }
-        if (preg_match('#^zalando#', Tools::strtolower($apiOrder->getChannel()->getName())) === false) {
-            return false;
+        if (preg_match('#^zalando#', Tools::strtolower($apiOrder->getChannel()->getName()))) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     public function afterOrderCreation($params)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Zalando rule is applied to all imported orders. Correct behavior is applying only to 'zalando' orders
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
