### PR TITLE
Error during xml feed creation (40129)

### DIFF
--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -70,7 +70,10 @@ class ShoppingfeedProductModuleFrontController extends \ModuleFrontController
         $fileXmlGz = '';
 
         if ($this->isCompressFeed) {
-            $fileXmlGz = sprintf('shoppingfeed-%s.xml.gz', Tools::hash($this->sfToken['id_shoppingfeed_token']));
+            $fileXmlGz = sprintf(
+                'shoppingfeed-%s.xml.gz',
+                $this->module->tools->hash($this->sfToken['id_shoppingfeed_token'])
+            );
             header('Content-Encoding: gzip');
             $productGenerator = new SfProductGenerator('compress.zlib://' . $fileXmlGz, 'xml');
         } else {

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -16,6 +16,9 @@
  * @copyright Since 2019 Shopping Feed
  * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
  */
+
+use ShoppingfeedAddon\Services\SfTools;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -284,9 +287,12 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
      *
      * @var string Unique token depend on _COOKIE_KEY_ which is unique to this website
      *
-     * @see Tools::encrypt()
+     * @see SfTools::hash()
      */
     public $secure_key;
+
+    /** @var SfTools */
+    public $tools;
 
     /**
      * creates an instance of the module
@@ -301,6 +307,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
         $this->ps_versions_compliancy = ['min' => '1.6', 'max' => '8.99.99'];
         $this->need_instance = false;
         $this->bootstrap = true;
+        $this->tools = new SfTools();
 
         parent::__construct();
 
@@ -309,7 +316,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
 
         $this->confirmUninstall = $this->l('Are you sure you want to uninstall?');
 
-        $this->secure_key = Tools::encrypt($this->name);
+        $this->secure_key = $this->tools->hash($this->name);
         if (version_compare(_PS_VERSION_, '1.7', '<')) {
             $this->moduleAdminControllers = [
                 [

--- a/src/Services/SfTools.php
+++ b/src/Services/SfTools.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2019 Shopping Feed
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright Since 2019 Shopping Feed
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace ShoppingfeedAddon\Services;
+
+use Tools;
+
+class SfTools
+{
+    public function hash($string)
+    {
+        if (version_compare(_PS_VERSION_, '1.7', '<')) {
+            return Tools::encrypt($string);
+        } else {
+            return Tools::hash($string);
+        }
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If PrestaShop version is 1.6 and the compress the product feed is enabled, then an error occurs during feed generation
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes 40129
| How to test?  | Load the feed on PS 1.6