### PR TITLE
refs #40131 products do not get to index

### DIFF
--- a/classes/actions/ShoppingfeedProductSyncPreloadingActions.php
+++ b/classes/actions/ShoppingfeedProductSyncPreloadingActions.php
@@ -56,7 +56,7 @@ class ShoppingfeedProductSyncPreloadingActions extends DefaultActions
 
         $sfModule = Module::getInstanceByName('shoppingfeed');
         $limit = Configuration::getGlobalValue(Shoppingfeed::STOCK_SYNC_MAX_PRODUCTS);
-        $nb_total_product = $sfModule->countProductsOnFeed();
+        $nb_total_product = $sfModule->countProductsOnFeed($token->id_shop);
         $nb_preloaded_product = (new ShoppingfeedPreloading())->getPreloadingCountForSync($token->id_shoppingfeed_token);
         if ($nb_total_product == $nb_preloaded_product) {
             return true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In context of the multishop env, the products that are missing in default shop don't get to index
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
