### PR TITLE
Selects categories in filters duplicate lines in multishop (40990)

### DIFF
--- a/controllers/admin/AdminShoppingfeedGeneralSettings.php
+++ b/controllers/admin/AdminShoppingfeedGeneralSettings.php
@@ -847,6 +847,8 @@ class AdminShoppingfeedGeneralSettingsController extends ShoppingfeedAdminContro
             ->leftJoin('category', 'c', 'cl.id_category = c.id_category')
             ->where('cl.id_lang = ' . (int) $this->context->language->id)
             ->where('c.id_parent <> 0')
+            ->where('cl.name <> ""')
+            ->where('cl.name IS NOT NULL')
             ->orderBy('c.id_category ASC')
             ->groupBy('cl.id_category')
             ->select('c.id_category as id, CONCAT("(", c.id_category, ")", " ", cl.name) as title');

--- a/controllers/admin/AdminShoppingfeedGeneralSettings.php
+++ b/controllers/admin/AdminShoppingfeedGeneralSettings.php
@@ -846,6 +846,7 @@ class AdminShoppingfeedGeneralSettingsController extends ShoppingfeedAdminContro
             ->from('category_lang', 'cl')
             ->leftJoin('category', 'c', 'cl.id_category = c.id_category')
             ->where('cl.id_lang = ' . (int) $this->context->language->id)
+            ->where('cl.id_shop = ' . (int) $this->context->shop->id)
             ->where('c.id_parent <> 0')
             ->orderBy('c.id_category ASC')
             ->select('c.id_category as id, CONCAT("(", c.id_category, ")", " ", cl.name) as title');

--- a/controllers/admin/AdminShoppingfeedGeneralSettings.php
+++ b/controllers/admin/AdminShoppingfeedGeneralSettings.php
@@ -846,9 +846,9 @@ class AdminShoppingfeedGeneralSettingsController extends ShoppingfeedAdminContro
             ->from('category_lang', 'cl')
             ->leftJoin('category', 'c', 'cl.id_category = c.id_category')
             ->where('cl.id_lang = ' . (int) $this->context->language->id)
-            ->where('cl.id_shop = ' . (int) $this->context->shop->id)
             ->where('c.id_parent <> 0')
             ->orderBy('c.id_category ASC')
+            ->groupBy('cl.id_category')
             ->select('c.id_category as id, CONCAT("(", c.id_category, ")", " ", cl.name) as title');
 
         exit(json_encode(Db::getInstance()->executeS($query)));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | category list in the filters contains duplicate categories if PS is multishop
| Type?         | bug fix 
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
