### PR TITLE
Fix batch id empty

### DIFF
--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -426,6 +426,9 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
             }
 
             $batchId = current($result->getBatchIds());
+            if (empty($batchId) === true) {
+                continue;
+            }
 
             foreach ($preparedTaskOrders as $preparedTaskOrder) {
                 $taskOrder = $preparedTaskOrder['taskOrder'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix batch id empty. In this case the next call will return all ticket from SF API that involved big troubles
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.