### PR TITLE
Bugfix pdf assign mass export (41053)

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1368,7 +1368,11 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
         }
 
         $additionalFields = json_decode($sfOrder->additionalFields, true);
-
+        // reset assigned variable in case of mass pdf export
+        $this->context->smarty->assign([
+            'id_customer' => '',
+            'order_id' => '',
+        ]);
         if (false === empty($additionalFields['customer_number'])) {
             $this->context->smarty->assign([
                 'id_customer' => $additionalFields['customer_number'],

--- a/views/templates/hook/displayPDFInvoice.tpl
+++ b/views/templates/hook/displayPDFInvoice.tpl
@@ -20,10 +20,10 @@
 * @copyright Copyright (c) 202-ecommerce
 * @license   Commercial license
 *}
-{if empty($id_customer) != false}
+{if empty($id_customer) === false}
     {l s='Customer ID' mod='shoppingfeed'} : {$id_customer|escape:'html':'UTF-8'} <br />
 {/if}
 
-{if empty($order_id) != false}
+{if empty($order_id) === false}
     {l s='Order ID Zalando' mod='shoppingfeed'} : {$order_id|escape:'html':'UTF-8'} <br />
 {/if}

--- a/views/templates/hook/displayPDFInvoice.tpl
+++ b/views/templates/hook/displayPDFInvoice.tpl
@@ -20,10 +20,10 @@
 * @copyright Copyright (c) 202-ecommerce
 * @license   Commercial license
 *}
-{if isset($id_customer)}
+{if empty($id_customer) != false}
     {l s='Customer ID' mod='shoppingfeed'} : {$id_customer|escape:'html':'UTF-8'} <br />
 {/if}
 
-{if isset($order_id)}
+{if empty($order_id) != false}
     {l s='Order ID Zalando' mod='shoppingfeed'} : {$order_id|escape:'html':'UTF-8'} <br />
 {/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In case of Laredoute order, PDF get specific content on invoices. If you make a mass export, laredoute assignation keep assigned
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 41053
| How to test?  | nc

