### PR TITLE
CLI prevent image URL on with double schema

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -41,8 +41,13 @@ foreach ($_SERVER['argv'] as $argv) {
 
 if (empty($params['controller']) || empty($params['secure_key']) || empty($path) === true) {
     echo 'Please define cli in absolute path, controller and secure_key as expected.' . "\r\n";
-    echo 'Usage: php ' . dirname(__FILE__) . '/cli.php controller=syncAll secure_key=db7a3a582a43e797a55842eced563d4a' . "\r\n";
+    echo 'Usage: php ' . dirname(__FILE__) . '/cli.php controller=syncAll secure_key=db7a3a582a43e797a55842eced563d4a ssl=off' . "\r\n";
     exit;
+}
+
+// prevent image URL with double schema
+if ($params['ssl'] != 'off') {
+    $_SERVER['SSL'] = 'on';
 }
 
 $_GET['fc'] = 'module';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Force SSL $_SERVER var to "on" to prevent iamge URL in product feed with double schema like : 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes nc
| How to test?  | Please indicate how to best verify that this PR is correct.
