### PR TITLE
ProductSerializer - add field 'min quantity for sale' (41039)

### DIFF
--- a/202/tests/ProductSerializer/TestAttributeTestCase.php
+++ b/202/tests/ProductSerializer/TestAttributeTestCase.php
@@ -52,6 +52,7 @@ class TestAttributeTestCase extends TestCase
         $productContent = json_decode($product['content'], true);
         $this->assertIsArray($productContent);
 
+        $this->assertEquals($productContent['min_quantity_for_sale'], 1);
         $this->assertEquals($productContent['price'], 28.68);
         $this->assertEquals($productContent['category']['name'], 'Root > Home > Clothes > Men');
         $this->assertEquals($productContent['brand']['name'], 'Studio Design');
@@ -78,6 +79,7 @@ class TestAttributeTestCase extends TestCase
         $this->assertEquals($productContent['variations'][1]['attributes']['Colorhexa'], '#ffffff');
         $this->assertEquals($productContent['variations'][1]['attributes']['Size'], 'S');
         $this->assertEquals($productContent['variations'][1]['attributes']['Color'], 'White');
+        $this->assertEquals($productContent['variations'][1]['min_quantity_for_sale'], 1);
     }
 
     public function testPrelodingTablePrice()

--- a/202/tests/ProductSerializer/TestAttributeTestCase.php
+++ b/202/tests/ProductSerializer/TestAttributeTestCase.php
@@ -79,7 +79,7 @@ class TestAttributeTestCase extends TestCase
         $this->assertEquals($productContent['variations'][1]['attributes']['Colorhexa'], '#ffffff');
         $this->assertEquals($productContent['variations'][1]['attributes']['Size'], 'S');
         $this->assertEquals($productContent['variations'][1]['attributes']['Color'], 'White');
-        $this->assertEquals($productContent['variations'][1]['min_quantity_for_sale'], 1);
+        $this->assertEquals($productContent['variations'][1]['attributes']['min_quantity_for_sale'], 1);
     }
 
     public function testPrelodingTablePrice()

--- a/202/tests/ProductSerializer/TestAttributeTestCase.php
+++ b/202/tests/ProductSerializer/TestAttributeTestCase.php
@@ -52,7 +52,6 @@ class TestAttributeTestCase extends TestCase
         $productContent = json_decode($product['content'], true);
         $this->assertIsArray($productContent);
 
-        $this->assertEquals($productContent['min_quantity_for_sale'], 1);
         $this->assertEquals($productContent['price'], 28.68);
         $this->assertEquals($productContent['category']['name'], 'Root > Home > Clothes > Men');
         $this->assertEquals($productContent['brand']['name'], 'Studio Design');
@@ -67,6 +66,7 @@ class TestAttributeTestCase extends TestCase
         $this->assertEquals($productContent['attributes']['hierararchy'], 'parent');
         $this->assertEquals($productContent['attributes']['mpn'], 'demo_1');
         $this->assertEquals($productContent['attributes']['supplier'], 'Fashion supplier');
+        $this->assertEquals($productContent['attributes']['min_quantity_for_sale'], 1);
         $this->assertIsString($productContent['attributes']['supplier_link']);
         $this->assertIsArray($productContent['images']);
         $this->assertEquals($productContent['attributes']['Composition'], 'Cotton');

--- a/src/Services/ProductAttributeCombination.php
+++ b/src/Services/ProductAttributeCombination.php
@@ -109,6 +109,7 @@ class ProductAttributeCombination
                 $combinations[$idProductAttribute]['reference'] = $row['reference'];
                 $combinations[$idProductAttribute]['wholesale_price'] = $row['wholesale_price'];
                 $combinations[$idProductAttribute]['ecotax'] = $row['ecotax'];
+                $combinations[$idProductAttribute]['minimal_quantity'] = $row['minimal_quantity'];
             }
 
             $combinations[$idProductAttribute]['attributes'][$row['group_name']] = $row['attribute_name'];

--- a/src/Services/ProductSerializer.php
+++ b/src/Services/ProductSerializer.php
@@ -405,8 +405,8 @@ class ProductSerializer
                 ],
                 'attributes' => [
                     'hierararchy' => 'child',
+                    'min_quantity_for_sale' => $combination['minimal_quantity'],
                 ],
-                'min_quantity_for_sale' => $combination['minimal_quantity'],
             ];
 
             if (empty($combination['ean13']) === false) {

--- a/src/Services/ProductSerializer.php
+++ b/src/Services/ProductSerializer.php
@@ -110,6 +110,7 @@ class ProductSerializer
             'images' => $this->getImages(),
             'attributes' => $this->getAttributes(),
             'variations' => $this->getVariations($carrier, $productLink),
+            'min_quantity_for_sale' => $this->product->minimal_quantity,
         ];
         if (empty($this->product->weight) === false && $this->product->weight != 0) {
             $content['weight'] = $this->product->weight;
@@ -405,6 +406,7 @@ class ProductSerializer
                 'attributes' => [
                     'hierararchy' => 'child',
                 ],
+                'min_quantity_for_sale' => $combination['minimal_quantity'],
             ];
 
             if (empty($combination['ean13']) === false) {

--- a/src/Services/ProductSerializer.php
+++ b/src/Services/ProductSerializer.php
@@ -110,7 +110,6 @@ class ProductSerializer
             'images' => $this->getImages(),
             'attributes' => $this->getAttributes(),
             'variations' => $this->getVariations($carrier, $productLink),
-            'min_quantity_for_sale' => $this->product->minimal_quantity,
         ];
         if (empty($this->product->weight) === false && $this->product->weight != 0) {
             $content['weight'] = $this->product->weight;
@@ -315,6 +314,7 @@ class ProductSerializer
             'ecotax' => $this->product->ecotax * (1 + ($this->product->tax_rate / 100)),
             'vat' => $this->product->tax_rate,
             'on_sale' => (int) $this->product->on_sale,
+            'min_quantity_for_sale' => $this->product->minimal_quantity,
             'hierararchy' => 'parent',
         ];
         if (empty($this->product->meta_title) === false) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  add field 'min quantity for sale'
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #41039
| How to test?  | Unit test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
