### PR TITLE
Add configuration for Test order not only canceled after import (40564)

### DIFF
--- a/202/tests/OrderImport/OrderRulesTestingTest.php
+++ b/202/tests/OrderImport/OrderRulesTestingTest.php
@@ -39,6 +39,22 @@ class OrderRulesTestingTest extends AbstractOrdeTestCase
         $this->assertTrue($rules->isApplicable($apiOrder));
     }
 
+    public function testOrderStatusChange(): void
+    {
+        $apiOrder = $this->getOrderRessourceFromDataset('order-amazon.json');
+
+        $rules = new TestingOrder(['order_status_after_test_order' => 1]);
+        $this->assertTrue($rules->isApplicable($apiOrder));
+    }
+
+    public function testOrderStatusRemainsSame(): void
+    {
+        $apiOrder = $this->getOrderRessourceFromDataset('order-amazon.json');
+
+        $rules = new TestingOrder(['order_status_after_test_order' => 0]);
+        $this->assertFalse($rules->isApplicable($apiOrder));
+    }
+
     /**
      * Test to import a standard order
      *

--- a/src/OrderImport/Rules/TestingOrder.php
+++ b/src/OrderImport/Rules/TestingOrder.php
@@ -40,7 +40,7 @@ class TestingOrder extends RuleAbstract implements RuleInterface
         // There's no check on the carrier name in the old module, so we won't
         // do it here either
         $orderRawData = $apiOrder->toArray();
-        if ($orderRawData['isTest']) {
+        if ($orderRawData['isTest'] && ((int) $this->configuration['order_status_after_test_order'])) {
             return true;
         }
 
@@ -118,6 +118,38 @@ class TestingOrder extends RuleAbstract implements RuleInterface
      */
     public function getDescription()
     {
-        return $this->l('Set order to CANCELED after the process.', 'TestingOrder');
+        return $this->l('After a successfull test import, turn this order into "Canceled" status', 'TestingOrder');
+    }
+
+    public function getConfigurationSubform()
+    {
+        $context = \Context::getContext();
+
+        $states[] = [
+            'type' => 'switch',
+            'label' => $this->l('After a successfull test import, turn this order into "Canceled" status', 'TestingOrder'),
+            'name' => 'order_status_after_test_order',
+            'required' => false,
+            'is_bool' => true,
+            'values' => [
+                [
+                    'id' => 'ok',
+                    'value' => 1,
+                ],
+                [
+                    'id' => 'ko',
+                    'value' => 0,
+                ],
+            ],
+        ];
+
+        return $states;
+    }
+
+    protected function getDefaultConfiguration()
+    {
+        return [
+            'order_status_after_test_order' => 1,
+        ];
     }
 }

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -216,6 +216,7 @@ $_MODULE['<{shoppingfeed}prestashop>testingorder_4ad367ed9d85670d0aee2e5d8feb114
 $_MODULE['<{shoppingfeed}prestashop>testingorder_eba2574749f45707a84aa0c6264d7207'] = 'Règle déclenchée. Configuration du statut de commande sur ANNULÉ.';
 $_MODULE['<{shoppingfeed}prestashop>testingorder_7523b11cd5b28c4360a2dd5b108245ae'] = 'Si la commande est un test';
 $_MODULE['<{shoppingfeed}prestashop>testingorder_7c5a72dfd28d60e1195279cf5c443d31'] = 'Régler la commande à ANNULEE après l\'import.';
+$_MODULE['<{shoppingfeed}prestashop>testingorder_ab48a2c29aa6f9bdd94c52ba6a4371e8'] = "Après l'import d'une commande de test, passer la commande au statut 'Annulé'";
 $_MODULE['<{shoppingfeed}prestashop>galerieslafayettecolissimo_0cc1e925b5703e8da52b7c3e91829499'] = '[Commande %s]';
 $_MODULE['<{shoppingfeed}prestashop>galerieslafayettecolissimo_43b6ade8fd758b0597ad2f31c9cd1b41'] = 'Règle déclenchée.';
 $_MODULE['<{shoppingfeed}prestashop>galerieslafayettecolissimo_44ec55560c396c0155f033420a501498'] = 'Si la commande provient de Galeries Lafayette et n\'a pas le champs \"other\" ou \"relayID\" vide.';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | update rule testing order
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #40564.
| How to test?  | Unit test.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
