### PR TITLE
Compatibility for PHP 5.6 - SfTools

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -16,7 +16,6 @@
  * @copyright Since 2019 Shopping Feed
  * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
  */
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -17,8 +17,6 @@
  * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
  */
 
-use ShoppingfeedAddon\Services\SfTools;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -37,6 +35,7 @@ require_once _PS_MODULE_DIR_ . 'shoppingfeed/vendor/autoload.php';
 // use ShoppingfeedAddon\Hook\HookDispatcher;
 // use ShoppingfeedAddon\ProductFilter\FilterFactory;
 // use ShoppingfeedAddon\Services\OrderTracker;
+// use ShoppingfeedAddon\Services\SfTools;
 
 /**
  * The base module class
@@ -307,7 +306,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
         $this->ps_versions_compliancy = ['min' => '1.6', 'max' => '8.99.99'];
         $this->need_instance = false;
         $this->bootstrap = true;
-        $this->tools = new SfTools();
+        $this->tools = new \ShoppingfeedAddon\Services\SfTools();
 
         parent::__construct();
 


### PR DESCRIPTION
Use full namespace for SfTools, avoiding module install error on PHP 5.6

<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There was a "use" statment in main module file, blocking the install on a PHP 5.6 server.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Try to zip / install the module on a old PS 1.6 with PHP 5.6.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
