### PR TITLE
Address issue #307: Undefined index: env in OrderImport 

### DIFF
--- a/src/OrderImport/Rules/ShippedByMarketplace.php
+++ b/src/OrderImport/Rules/ShippedByMarketplace.php
@@ -257,6 +257,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         try {
             $paymentInformation = $apiOrder->getPaymentInformation();
+
             return
                 isset($paymentInformation['method']) &&
                 strpos(strtolower($paymentInformation['method']), 'afn') !== false;
@@ -274,6 +275,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         try {
             $paymentOrderInformation = $apiOrder->getPaymentInformation();
+
             return
                 isset($paymentOrderInformation['method']) &&
                 strpos(strtolower($paymentOrderInformation['method']), 'clogistique') !== false;
@@ -291,6 +293,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     {
         try {
             $apiOrderArray = $apiOrder->toArray();
+
             return
                 isset($apiOrderArray['additionalFields']['env']) &&
                 strtolower($apiOrderArray['additionalFields']['env']) == 'epmm';

--- a/src/OrderImport/Rules/ShippedByMarketplace.php
+++ b/src/OrderImport/Rules/ShippedByMarketplace.php
@@ -256,7 +256,10 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     protected function isShippedAmazon(OrderResource $apiOrder)
     {
         try {
-            return strpos(strtolower($apiOrder->getPaymentInformation()['method']), 'afn') !== false;
+            $paymentInformation = $apiOrder->getPaymentInformation();
+            return
+                isset($paymentInformation['method']) &&
+                strpos(strtolower($paymentInformation['method']), 'afn') !== false;
         } catch (\Throwable $e) {
             return false;
         }
@@ -270,7 +273,10 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     protected function isShippedCdiscount(OrderResource $apiOrder)
     {
         try {
-            return strpos(strtolower($apiOrder->getPaymentInformation()['method']), 'clogistique') !== false;
+            $paymentOrderInformation = $apiOrder->getPaymentInformation();
+            return
+                isset($paymentOrderInformation['method']) &&
+                strpos(strtolower($paymentOrderInformation['method']), 'clogistique') !== false;
         } catch (\Throwable $e) {
             return false;
         }
@@ -284,7 +290,10 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
     protected function isShippedManomano(OrderResource $apiOrder)
     {
         try {
-            return strtolower($apiOrder->toArray()['additionalFields']['env']) == 'epmm';
+            $apiOrderArray = $apiOrder->toArray();
+            return
+                isset($apiOrderArray['additionalFields']['env']) &&
+                strtolower($apiOrderArray['additionalFields']['env']) == 'epmm';
         } catch (\Throwable $e) {
             return false;
         }


### PR DESCRIPTION
Test array key isset before trying to access it.

<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix issue of Undefined index: env in OrderImport
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #307
| How to test?  | No more php warning `Undefined index: env in OrderImport` in order synchronisation cron task.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
