### PR TITLE
Fix cleaning of old task order status sync (42833)

### DIFF
--- a/controllers/front/syncOrder.php
+++ b/controllers/front/syncOrder.php
@@ -234,27 +234,17 @@ class ShoppingfeedSyncOrderModuleFrontController extends ShoppingfeedCronControl
                 );
             }
 
-            // Delete all processed task orders
-            $processedTaskOrders = array_merge(
-                $successfulTicketsStatusTaskOrders,
-                $failedTicketsStatusTaskOrders
-            );
-            foreach ($processedTaskOrders as $taskOrder) {
+            // Delete successfully processed task orders
+            foreach ($successfulTicketsStatusTaskOrders as $taskOrder) {
                 $taskOrder->delete();
             }
-
             //Resend failed tickets.
-            $handler = new ActionsHandler();
-
             foreach ($failedTicketsStatusTaskOrders as $failedTicket) {
                 /* @var ShoppingfeedTaskOrder $failedTicket*/
-                $handler
-                    ->setConveyor([
-                        'id_order' => $failedTicket->id_order,
-                        'order_action' => ShoppingfeedTaskOrder::ACTION_SYNC_STATUS,
-                    ])
-                    ->addActions('saveTaskOrder');
-                $handler->process('shoppingfeedOrderSync');
+                $failedTicket->action = ShoppingfeedTaskOrder::ACTION_SYNC_STATUS;
+                $failedTicket->ticket_number = '';
+                $failedTicket->batch_id = '';
+                $failedTicket->save();
             }
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Automatic cleaning of the old order task doesn't work
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
