### PR TITLE
Feature/35364 using id order in api calls + sending the status 'Delivered'

### DIFF
--- a/classes/ShoppingfeedApi.php
+++ b/classes/ShoppingfeedApi.php
@@ -246,24 +246,36 @@ class ShoppingfeedApi
             foreach ($taskOrders as $taskOrder) {
                 switch ($taskOrder['operation']) {
                     case OrderOperation::TYPE_SHIP:
-                        $operation->ship(
-                            $taskOrder['reference_marketplace'],
-                            $taskOrder['marketplace'],
-                            $taskOrder['payload']['carrier_name'],
-                            $taskOrder['payload']['tracking_number'],
-                            $taskOrder['payload']['tracking_url']
+                        $operation->addOperation(
+                            (string) $taskOrder['reference_marketplace'],
+                            (string) $taskOrder['marketplace'],
+                            $taskOrder['operation'],
+                            [
+                                'id' => (string) $taskOrder['id_internal_shoppingfeed'],
+                                'carrier' => (string) $taskOrder['payload']['carrier_name'],
+                                'trackingNumber' => (string) $taskOrder['payload']['tracking_number'],
+                                'trackingLink' => (string) $taskOrder['payload']['tracking_url'],
+                            ]
                         );
                         continue 2;
                     case OrderOperation::TYPE_CANCEL:
-                        $operation->cancel(
-                            $taskOrder['reference_marketplace'],
-                            $taskOrder['marketplace']
+                        $operation->addOperation(
+                            (string) $taskOrder['reference_marketplace'],
+                            (string) $taskOrder['marketplace'],
+                            $taskOrder['operation'],
+                            [
+                                'id' => (string) $taskOrder['id_internal_shoppingfeed'],
+                            ]
                         );
                         continue 2;
                     case OrderOperation::TYPE_REFUND:
-                        $operation->refund(
-                            $taskOrder['reference_marketplace'],
-                            $taskOrder['marketplace']
+                        $operation->addOperation(
+                            (string) $taskOrder['reference_marketplace'],
+                            (string) $taskOrder['marketplace'],
+                            $taskOrder['operation'],
+                            [
+                                'id' => (string) $taskOrder['id_internal_shoppingfeed'],
+                            ]
                         );
                         continue 2;
                 }

--- a/classes/ShoppingfeedApi.php
+++ b/classes/ShoppingfeedApi.php
@@ -278,6 +278,16 @@ class ShoppingfeedApi
                             ]
                         );
                         continue 2;
+                    case OrderOperation::TYPE_DELIVER:
+                        $operation->addOperation(
+                            (string) $taskOrder['reference_marketplace'],
+                            (string) $taskOrder['marketplace'],
+                            $taskOrder['operation'],
+                            [
+                                'id' => (string) $taskOrder['id_internal_shoppingfeed'],
+                            ]
+                        );
+                        continue 2;
                 }
             }
 

--- a/classes/ShoppingfeedApi.php
+++ b/classes/ShoppingfeedApi.php
@@ -413,19 +413,29 @@ class ShoppingfeedApi
         return $filteredOrders;
     }
 
-    public function acknowledgeOrder($id_order_marketplace, $name_marketplace, $id_order_prestashop, $is_success = true, $message = '')
-    {
+    public function acknowledgeOrder(
+        $id_order_marketplace,
+        $ref_order_marketplace,
+        $name_marketplace,
+        $id_order_prestashop,
+        $is_success = true,
+        $message = ''
+    ) {
         try {
             $orderApi = $this->session->getMainStore()->getOrderApi();
-            $operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-            $operation
-                ->acknowledge(
-                    (string) $id_order_marketplace,
-                    (string) $name_marketplace,
-                    (string) $id_order_prestashop,
-                    ($is_success === true) ? 'success' : 'error',
-                    $message
-                );
+            $operation = new OrderOperation();
+            $operation->addOperation(
+                (string) $ref_order_marketplace,
+                (string) $name_marketplace,
+                OrderOperation::TYPE_ACKNOWLEDGE,
+                [
+                    'id' => (string) $id_order_marketplace,
+                    'status' => ($is_success === true) ? 'success' : 'error',
+                    'storeReference' => (string) $id_order_prestashop,
+                    'message' => (string) $message,
+                    'acknowledgedAt' => date_create()->format('c'),
+                ]
+            );
 
             return $orderApi->execute($operation);
         } catch (Exception $e) {

--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -873,6 +873,7 @@ class ShoppingfeedOrderImportActions extends DefaultActions
 
         try {
             $result = $shoppingfeedApi->acknowledgeOrder(
+                $apiOrder->getId(),
                 $apiOrder->getReference(),
                 $apiOrder->getChannel()->getName(),
                 isset($this->conveyor['id_order']) ? $this->conveyor['id_order'] : null,

--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -372,6 +372,7 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
             }
 
             $this->conveyor['preparedTaskOrders'][$taskOrderOperation][] = [
+                'id_internal_shoppingfeed' => $sfOrder->id_internal_shoppingfeed,
                 'reference_marketplace' => $sfOrder->id_order_marketplace,
                 'marketplace' => $sfOrder->name_marketplace,
                 'taskOrder' => $taskOrder,

--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -256,9 +256,10 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
         }
         $taskOrders = $this->conveyor['taskOrders'];
 
-        $shipped_status = json_decode(Configuration::get(Shoppingfeed::SHIPPED_ORDERS, null, null, $id_shop));
-        $cancelled_status = json_decode(Configuration::get(Shoppingfeed::CANCELLED_ORDERS, null, null, $id_shop));
-        $refunded_status = json_decode(Configuration::get(Shoppingfeed::REFUNDED_ORDERS, null, null, $id_shop));
+        $shipped_status = json_decode(Configuration::get(Shoppingfeed::SHIPPED_ORDERS, null, null, $id_shop), true);
+        $cancelled_status = json_decode(Configuration::get(Shoppingfeed::CANCELLED_ORDERS, null, null, $id_shop), true);
+        $refunded_status = json_decode(Configuration::get(Shoppingfeed::REFUNDED_ORDERS, null, null, $id_shop), true);
+        $delivered_status = json_decode(Configuration::get(Shoppingfeed::DELIVERED_ORDERS, null, null, $id_shop), true);
 
         $this->conveyor['preparedTaskOrders'] = [];
         foreach ($taskOrders as $taskOrder) {
@@ -353,8 +354,10 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
                 } elseif (in_array($idOrderState, $refunded_status)) {
                     $taskOrderOperation = OrderOperation::TYPE_REFUND;
                     continue;
-                    // No partial refund (at least for now), so no optional
+                // No partial refund (at least for now), so no optional
                     // parameters to set.
+                } elseif (in_array($idOrderState, $delivered_status)) {
+                    $taskOrderOperation = OrderOperation::TYPE_DELIVER;
                 }
             }
 

--- a/controllers/admin/AdminShoppingfeedOrderImportRules.php
+++ b/controllers/admin/AdminShoppingfeedOrderImportRules.php
@@ -174,15 +174,20 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
         $allState = OrderState::getOrderStates($this->context->language->id);
 
         $orderShippedState = [];
+        $orderDeliveredState = [];
         $orderCancelledState = [];
         $orderRefundedState = [];
 
         $ids_shipped_status_selected = json_decode(Configuration::get(Shoppingfeed::SHIPPED_ORDERS));
         $ids_cancelled_status_selected = json_decode(Configuration::get(Shoppingfeed::CANCELLED_ORDERS));
-
         $ids_refunded_status_selected = json_decode(Configuration::get(Shoppingfeed::REFUNDED_ORDERS));
+        $ids_delivered_status_selected = json_decode(Configuration::get(Shoppingfeed::DELIVERED_ORDERS));
+
         if (!is_array($ids_refunded_status_selected)) {
             $ids_refunded_status_selected = [$ids_refunded_status_selected];
+        }
+        if (!is_array($ids_delivered_status_selected)) {
+            $ids_delivered_status_selected = [];
         }
 
         $orderShippedState['selected'] = [];
@@ -204,6 +209,11 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
             ];
 
             $orderRefundedState[in_array($state['id_order_state'], $ids_refunded_status_selected) ? 'selected' : 'unselected'][] = [
+                'value' => $state['id_order_state'],
+                'label' => $state['name'],
+            ];
+
+            $orderDeliveredState[in_array($state['id_order_state'], $ids_delivered_status_selected) ? 'selected' : 'unselected'][] = [
                 'value' => $state['id_order_state'],
                 'label' => $state['name'],
             ];
@@ -427,6 +437,30 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
                         ],
                         [
                             'type' => 'shoppingfeed_double-list',
+                            'name' => 'status_delivered_order',
+                            'label' => $this->module->l('Delivery orders synchronization + Status mapping', 'AdminShoppingfeedOrderImportRules'),
+                            'hint' => $this->module->l('When the order has been delivered to the customer, for platforms managing this status', 'AdminShoppingfeedOrderImportRules'),
+                            'unselected' => [
+                                'id' => 'status_delivered_order_add',
+                                'label' => $this->module->l('Unselected order status', 'AdminShoppingfeedOrderImportRules'),
+                                'options' => $orderDeliveredState['unselected'],
+                                'btn' => [
+                                    'id' => 'status_delivered_order_btn',
+                                    'label' => $this->module->l('Add', 'AdminShoppingfeedOrderImportRules'),
+                                ],
+                            ],
+                            'selected' => [
+                                'id' => 'status_delivered_order_remove',
+                                'label' => $this->module->l('Selected order status', 'AdminShoppingfeedOrderImportRules'),
+                                'options' => $orderDeliveredState['selected'],
+                                'btn' => [
+                                    'id' => 'status_delivered_order_remove_btn',
+                                    'label' => $this->module->l('Remove', 'AdminShoppingfeedOrderImportRules'),
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'shoppingfeed_double-list',
                             'name' => 'status_cancelled_order',
                             'label' => $this->module->l('Cancelled orders synchronization', 'AdminShoppingfeedOrderImportRules'),
                             'unselected' => [
@@ -611,6 +645,11 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
             $orderStatusesShipped = [];
         }
 
+        $orderStatusesDelivered = Tools::getValue('status_delivered_order');
+        if (!is_array($orderStatusesDelivered)) {
+            $orderStatusesDelivered = [];
+        }
+
         $orderStatusesCancelled = Tools::getValue('status_cancelled_order');
         if (!$orderStatusesCancelled) {
             $orderStatusesCancelled = [];
@@ -633,6 +672,7 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
             Configuration::updateValue(Shoppingfeed::ORDER_STATUS_TIME_SHIFT, (int) $tracking_timeshift);
             Configuration::updateValue(Shoppingfeed::CANCELLED_ORDERS, json_encode($orderStatusesCancelled));
             Configuration::updateValue(Shoppingfeed::REFUNDED_ORDERS, json_encode($orderStatusRefunded));
+            Configuration::updateValue(Shoppingfeed::DELIVERED_ORDERS, json_encode($orderStatusesDelivered));
             Configuration::updateValue(Shoppingfeed::ORDER_STATUS_MAX_ORDERS, $max_orders);
             Configuration::updateValue(Shoppingfeed::ORDER_DEFAULT_CARRIER_REFERENCE, Tools::getValue(Shoppingfeed::ORDER_DEFAULT_CARRIER_REFERENCE));
         }

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -60,6 +60,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
     const SHIPPED_ORDERS = 'SHOPPINGFEED_SHIPPED_ORDERS';
     const CANCELLED_ORDERS = 'SHOPPINGFEED_CANCELLED_ORDERS';
     const REFUNDED_ORDERS = 'SHOPPINGFEED_REFUNDED_ORDERS';
+    const DELIVERED_ORDERS = 'SHOPPINGFEED_DELIVERED_ORDERS';
     const ORDER_IMPORT_ENABLED = 'SHOPPINGFEED_ORDER_IMPORT_ENABLED';
     const ORDER_IMPORT_TEST = 'SHOPPINGFEED_ORDER_IMPORT_TEST';
     const ORDER_IMPORT_SHIPPED = 'SHOPPINGFEED_ORDER_IMPORT_SHIPPED';
@@ -435,6 +436,7 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
         $this->setConfigurationDefault(self::SHIPPED_ORDERS, json_encode([]));
         $this->setConfigurationDefault(self::CANCELLED_ORDERS, json_encode([]));
         $this->setConfigurationDefault(self::REFUNDED_ORDERS, json_encode([]));
+        $this->setConfigurationDefault(self::DELIVERED_ORDERS, json_encode([]));
         $this->setConfigurationDefault(self::ORDER_IMPORT_ENABLED, true);
         $this->setConfigurationDefault(self::ORDER_IMPORT_SHIPPED, false);
         $this->setConfigurationDefault(self::ORDER_IMPORT_SPECIFIC_RULES_CONFIGURATION, json_encode([]));

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1241,9 +1241,11 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
         $shipped_status = json_decode(Configuration::get(Shoppingfeed::SHIPPED_ORDERS, null, null, $order->id_shop));
         $cancelled_status = json_decode(Configuration::get(Shoppingfeed::CANCELLED_ORDERS, null, null, $order->id_shop));
         $refunded_status = json_decode(Configuration::get(Shoppingfeed::REFUNDED_ORDERS, null, null, $order->id_shop));
+        $delivered_status = json_decode(Configuration::get(Shoppingfeed::DELIVERED_ORDERS, null, null, $order->id_shop));
         if (!in_array($newOrderStatus->id, $shipped_status)
             && !in_array($newOrderStatus->id, $cancelled_status)
             && !in_array($newOrderStatus->id, $refunded_status)
+            && !in_array($newOrderStatus->id, $delivered_status)
         ) {
             return;
         }

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -558,6 +558,8 @@ $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedorderimportrules_b9d1b8558d
 $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedorderimportrules_ceff443491edd888ee91e6bef87446a6'] = 'Vous devez spécifier un \"Délai avant la synchronisation du numéro de suivi\" supérieur à 0.';
 $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedorderimportrules_23b574c89c8eafae9531357e5763d00f'] = 'Vous devez spécifier un \"Nombre de commandes maximum\" entre 1 et 200.';
 $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedorderimportrules_67838a580a67c01392c8bc906654228a'] = 'Séelctionner un transporteur';
+$_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedorderimportrules_541d50ff4f79ad3c125b154568146103'] = 'Synchronisation des commandes reçues + Status mapping';
+$_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedorderimportrules_0147ea0808683b0b0b2a66d987b3db2d'] = 'Lorsque la commande a bien été livrée chez le client, pour les plateformes gérant ce statut';
 $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedprocessmonitor_b6543e6dabc6a1cbf66f92026508ec24'] = 'Impossible de troiuver la déclaration des tâches cron dans le module.';
 $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedprocessmonitor_965834fed9e23894a358742da10f6343'] = 'Nom technique';
 $_MODULE['<{shoppingfeed}prestashop>adminshoppingfeedprocessmonitor_b78a3223503896721cca1303f776159b'] = 'Titre';

--- a/vendor/prefixed/shoppingfeed/php-sdk/src/Api/Order/OrderOperation.php
+++ b/vendor/prefixed/shoppingfeed/php-sdk/src/Api/Order/OrderOperation.php
@@ -21,6 +21,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
     public const TYPE_ACKNOWLEDGE      = 'acknowledge';
     public const TYPE_UNACKNOWLEDGE    = 'unacknowledge';
     public const TYPE_UPLOAD_DOCUMENTS = 'upload-documents';
+    public const TYPE_DELIVER          = 'deliver';
 
     /**
      * @var array
@@ -34,6 +35,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         self::TYPE_ACKNOWLEDGE,
         self::TYPE_UNACKNOWLEDGE,
         self::TYPE_UPLOAD_DOCUMENTS,
+        self::TYPE_DELIVER,
     ];
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Current PR takes into account the API modifications and adopts the existing used calls to the new requirements, namely sending internal  SF order ID in the order operation calls ship/cancel/refund/acknowledge.
In addition, there is an added possibility to apply the status 'delivered'.
| Type?         | new feature
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes 35364
| How to test?  | 
