### PR TITLE
Add company name on colissimo address for ManoMano (43707)

### DIFF
--- a/src/OrderImport/Rules/AbstractColissimo.php
+++ b/src/OrderImport/Rules/AbstractColissimo.php
@@ -95,7 +95,7 @@ abstract class AbstractColissimo extends RuleAbstract implements RuleInterface
         // Save/update Colissimo pickup point
         $pickupPointData = [
             'colissimo_id' => $colissimoPickupPointId,
-            'company_name' => $shippingAddressObj->company,
+            'company_name' => $shippingAddressObj->company ? $shippingAddressObj->company : 'undefined',
             'address1' => $shippingAddressObj->address1,
             'address2' => $shippingAddressObj->address2,
             'city' => $shippingAddressObj->city,

--- a/src/OrderImport/Rules/MonechelleColissimo.php
+++ b/src/OrderImport/Rules/MonechelleColissimo.php
@@ -115,4 +115,27 @@ class MonechelleColissimo extends AbstractColissimo implements RuleInterface
 
         return parent::afterCartCreation($params);
     }
+
+    public function onPreProcess($params)
+    {
+        /** @var \ShoppingfeedAddon\OrderImport\OrderData $orderData */
+        $orderData = $params['orderData'];
+        $fullNameArray = explode(' ', trim($orderData->shippingAddress['firstName']));
+        $lastName = $orderData->shippingAddress['lastName'];
+
+        if (false === empty($orderData->shippingAddress['company'])) {
+            return;
+        }
+        if (count($fullNameArray) < 2) {
+            return;
+        }
+
+        $orderData->shippingAddress['firstName'] = $fullNameArray[0];
+        $orderData->shippingAddress['lastName'] = implode(' ', array_slice($fullNameArray, 1));
+        $orderData->shippingAddress['company'] = sprintf(
+            '%s (%s)',
+            (string) $lastName,
+            (string) $this->getRelayId($params['apiOrder'])
+        );
+    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | company is a mandatory field for colissimo carriers. The following modifications use a string 'undefined' if a company is not provided. Also they try extract the company name from the 'lastName' of  Monechelle shipping address.
| Type?         | bug fix 
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes 43707
| How to test?  | Please indicate how to best verify that this PR is correct.
