### PR TITLE
Sync Order task throw an error and return false instead of continuing (43970)

### DIFF
--- a/controllers/front/syncOrder.php
+++ b/controllers/front/syncOrder.php
@@ -281,7 +281,7 @@ class ShoppingfeedSyncOrderModuleFrontController extends ShoppingfeedCronControl
                         $this->processMonitor->getProcessObjectModelId()
                     );
 
-                    return false;
+                    continue;
                 }
 
                 $result = $shoppingfeedApi->getUnacknowledgedOrders();
@@ -299,7 +299,7 @@ class ShoppingfeedSyncOrderModuleFrontController extends ShoppingfeedCronControl
                     $this->processMonitor->getProcessObjectModelId()
                 );
 
-                return false;
+                continue;
             }
             if (empty($result) === true) {
                 ProcessLoggerHandler::logInfo(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The sync Order cron throw an error and return false instead of continuing the process with following 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 
| How to test?  | 

