### PR TITLE
Fix warning on the configuration page (43962)

### DIFF
--- a/controllers/admin/AdminShoppingfeedOrderImportRules.php
+++ b/controllers/admin/AdminShoppingfeedOrderImportRules.php
@@ -51,6 +51,7 @@ class AdminShoppingfeedOrderImportRulesController extends ShoppingfeedAdminContr
         $this->addJS($this->module->getPathUri() . 'views/js/form_config.js');
         $this->content = $this->welcomeForm();
         $id_shop = $this->context->shop->id;
+        $this->identifier = 'className';
 
         $sft = new ShoppingfeedToken();
         $tokens = $sft->findAllActive();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | fix for the warning on the configuration page
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes 43962
| How to test?  | Please indicate how to best verify that this PR is correct.

![1705403581708](https://github.com/shoppingflux/module-prestashop/assets/44570209/8c1507d9-2eae-4ecc-8675-15a4d1545ba8)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
