### PR TITLE
Set a shop in a context according to a token configurations (44375)

### DIFF
--- a/controllers/front/syncOrder.php
+++ b/controllers/front/syncOrder.php
@@ -312,6 +312,8 @@ class ShoppingfeedSyncOrderModuleFrontController extends ShoppingfeedCronControl
 
             Registry::set('errors', 0);
             Registry::set('importedOrders', 0);
+            Shop::setContext(Shop::CONTEXT_SHOP, $id_shop);
+            $this->context->shop = new Shop($id_shop);
             foreach ($result as $apiOrder) {
                 $logPrefix = sprintf(
                     $this->module->l('[Order: %s]', 'syncOrder'),

--- a/controllers/front/syncProduct.php
+++ b/controllers/front/syncProduct.php
@@ -117,6 +117,7 @@ class ShoppingfeedSyncProductModuleFrontController extends ShoppingfeedCronContr
         try {
             foreach ($tokens as $token) {
                 Shop::setContext(Shop::CONTEXT_SHOP, $token['id_shop']);
+                $this->context->shop = new Shop((int) $token['id_shop']);
                 $logPrefix = $actionClassname::getLogPrefix($token['id_shoppingfeed_token']);
                 $handler->setConveyor([
                     'id_token' => $token['id_shoppingfeed_token'],


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If multishop is used, and several tokens are configured (for each shop), and the prices are different according to the shop, then the prices are  incorrect since the wrong shop is taken into account.
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes 44375
| How to test?  | 
