### PR TITLE
Make the relay point id an optional for gls rule (44516)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
       }
   },
   "scripts": {
-    "pre-autoload-dump": ""
+    "pre-autoload-dump": "#if [ ${TOTPSCLASSLIB_DEV_PATH} ]; then php ${TOTPSCLASSLIB_DEV_PATH}/classlib/refresh.php .; fi"
   },
   "type": "prestashop-module"
 }

--- a/src/OrderImport/GLS/CartCarrierAssociation.php
+++ b/src/OrderImport/GLS/CartCarrierAssociation.php
@@ -38,23 +38,23 @@ class CartCarrierAssociation
         $this->glsAdapter = $glsAdapter;
     }
 
-    public function create(Cart $cart, $relayId)
+    public function create(Cart $cart, $relayId = null)
     {
-        try {
-            $relay_detail = $this->glsAdapter->getRelayDetail($relayId);
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+        $relay_detail = [];
+
+        if (false === empty($relayId)) {
+            try {
+                $relay_detail = $this->glsAdapter->getRelayDetail($relayId);
+            } catch (Exception $e) {
+                throw new Exception($e->getMessage());
+            }
         }
 
-        if (empty($relay_detail)) {
-            throw new Exception('Data of relay point is missing');
-        }
-
-        $id_country = Country::getByIso($relay_detail['Country']);
         $address = new Address($cart->id_address_delivery);
+        $country = new Country(empty($relay_detail['Country']) ? $address->id_country : Country::getByIso($relay_detail['Country']));
         $gls_product = $this->glsAdapter->getGlsProductCode(
             Configuration::get('GLS_GLSRELAIS_ID', (int) $cart->id_carrier, $cart->id_shop_group, $cart->id_shop),
-            $relay_detail['Country']
+            $country->iso_code
         );
 
         $this->db->delete('gls_cart_carrier', 'id_cart = "' . pSQL($cart->id) . '"');
@@ -63,17 +63,17 @@ class CartCarrierAssociation
                 '" . (int) $cart->id_customer . "',
                 '" . (int) Configuration::get('GLS_GLSRELAIS_ID', (int) $cart->id_carrier, $cart->id_shop_group, $cart->id_shop) . "',
                 '" . pSQL($gls_product) . "',
-                '" . pSQL($relayId) . "',
-                '" . pSQL($relay_detail['Name1']) . "',
-                '" . pSQL($relay_detail['Street1']) . "',
-                '" . pSQL($relay_detail['Street2']) . "',
-                '" . pSQL($relay_detail['ZipCode']) . "',
-                '" . pSQL($relay_detail['City']) . "',
-                '" . pSQL($relay_detail['Phone']) . "',
-                '" . pSQL($relay_detail['Mobile']) . "',
+                '" . (empty($relayId) ? '' : pSQL($relayId)) . "',
+                '" . (empty($relay_detail['Name1']) ? '' : pSQL($relay_detail['Name1'])) . "',
+                '" . (empty($relay_detail['Street1']) ? '' : pSQL($relay_detail['Street1'])) . "',
+                '" . (empty($relay_detail['Street2']) ? '' : pSQL($relay_detail['Street2'])) . "',
+                '" . (empty($relay_detail['ZipCode']) ? '' : pSQL($relay_detail['ZipCode'])) . "',
+                '" . (empty($relay_detail['City']) ? '' : pSQL($relay_detail['City'])) . "',
+                '" . (empty($relay_detail['Phone']) ? '' : pSQL($relay_detail['Phone'])) . "',
+                '" . (empty($relay_detail['Mobile']) ? '' : pSQL($relay_detail['Mobile'])) . "',
                 '" . pSQL($address->phone_mobile) . "',
-                '" . (int) $id_country . "',
-                '" . pSQL(json_encode($relay_detail['GLSWorkingDay'])) . "'
+                '" . (int) $country->id . "',
+                '" . (empty($relay_detail['GLSWorkingDay']) ? '' : pSQL(json_encode($relay_detail['GLSWorkingDay']))) . "'
             )";
 
         return $this->db->execute($sql);

--- a/src/OrderImport/Rules/GlsRule.php
+++ b/src/OrderImport/Rules/GlsRule.php
@@ -57,14 +57,9 @@ class GlsRule extends RuleAbstract implements RuleInterface
         );
         $this->logPrefix .= '[' . $apiOrder->getReference() . '] ' . self::class . ' | ';
 
-        if (false == $this->isModuleGlsInstalled() || empty($this->getRelayId($apiOrder))) {
+        if (false == $this->isModuleGlsInstalled()) {
             return false;
         }
-
-        ProcessLoggerHandler::logInfo(
-            $this->logPrefix .
-            $this->l('Rule triggered.', 'GlsRule')
-        );
 
         return true;
     }
@@ -94,19 +89,13 @@ class GlsRule extends RuleAbstract implements RuleInterface
         }
         $carrier = new Carrier($cart->id_carrier);
         if ($carrier->external_module_name != $this->gls->name) {
-            ProcessLoggerHandler::logError(
-                $this->logPrefix .
-                sprintf(
-                    $this->l('Fail linking GLS pickup point %s to cart %d. GLS carrier no properly set on carrier matching of ShoppingFeed module.', 'GlsRule'),
-                    $this->getRelayId($params['apiOrder']),
-                    (int) $cart->id
-                ),
-                'Cart',
-                $cart->id
-            );
-
             return;
         }
+
+        ProcessLoggerHandler::logInfo(
+            $this->logPrefix .
+            $this->l('Rule triggered.', 'GlsRule')
+        );
 
         $cartCarrierAssociation = $this->initCartCarrierAssociation();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Apply the GLS rule even if the relay point id is absent (in the case of "Home delivery"). 
| Type?         | improvement
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
