### PR TITLE
Fix switch option display Real-time sync (45406)

### DIFF
--- a/controllers/admin/AdminShoppingfeedGeneralSettings.php
+++ b/controllers/admin/AdminShoppingfeedGeneralSettings.php
@@ -528,9 +528,9 @@ class AdminShoppingfeedGeneralSettingsController extends ShoppingfeedAdminContro
             Shoppingfeed::PRODUCT_SYNC_BY_DATE_UPD => $syncByDateUpdate,
             Shoppingfeed::PRODUCT_FEED_TIME_FULL_UPDATE => $time_full_update,
             Shoppingfeed::PRODUCT_FEED_INTERVAL_CRON => $interval_cron,
-            Shoppingfeed::REAL_TIME_SYNCHRONIZATION => Configuration::get(Shoppingfeed::REAL_TIME_SYNCHRONIZATION),
+            Shoppingfeed::REAL_TIME_SYNCHRONIZATION => (int) Configuration::get(Shoppingfeed::REAL_TIME_SYNCHRONIZATION),
             Shoppingfeed::STOCK_SYNC_MAX_PRODUCTS => Configuration::get(Shoppingfeed::STOCK_SYNC_MAX_PRODUCTS),
-            Shoppingfeed::COMPRESS_PRODUCTS_FEED => Configuration::get(Shoppingfeed::COMPRESS_PRODUCTS_FEED),
+            Shoppingfeed::COMPRESS_PRODUCTS_FEED => (int) Configuration::get(Shoppingfeed::COMPRESS_PRODUCTS_FEED),
             'with_factory' => Tools::getValue('with_factory'),
         ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Incorrect displaying the switch option 'Real-time synchronization'
| Type?         | bug fix 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
