### PR TITLE
Exception throw on orderCarrier date_add

### DIFF
--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1168,6 +1168,7 @@ class ShoppingfeedOrderImportActions extends DefaultActions
             if ($id_order_carrier) {
                 Db::getInstance()->update('order_carrier', $updateOrderTracking, '`id_order_carrier` = ' . (int) $id_order_carrier);
             } else {
+                $updateOrderTracking['date_add'] = date('Y-m-d H:i:s');
                 Db::getInstance()->insert('order_carrier', $updateOrderTracking);
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The property OrderCarrier->date_add is not valid
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | Fixes 46127
| How to test?  | nc
