### PR TITLE
json_decode(): Passing null to parameter on product feed (47566)

### DIFF
--- a/classes/ShoppingfeedPreloading.php
+++ b/classes/ShoppingfeedPreloading.php
@@ -276,7 +276,7 @@ class ShoppingfeedPreloading extends ObjectModel
 
             return $this->save();
         }
-        $actions = json_decode($this->actions, true);
+        $actions = json_decode((string) $this->actions, true);
         if (is_array($actions) === false) {
             $this->actions = json_encode([$action]);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Error a product update. json_decode(): Passing null to parameter on product feed
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 47566
| How to test?  | Please indicate how to best verify that this PR is correct.
