### PR TITLE
Fix GLS _DB_PREFIX_ for PS 1.6 (47842)

### DIFF
--- a/src/OrderImport/GLS/CartCarrierAssociation.php
+++ b/src/OrderImport/GLS/CartCarrierAssociation.php
@@ -58,7 +58,7 @@ class CartCarrierAssociation
         );
 
         $this->db->delete('gls_cart_carrier', 'id_cart = "' . pSQL($cart->id) . '"');
-        $sql = 'INSERT IGNORE INTO ' . $this->db->getPrefix() . "gls_cart_carrier VALUES (
+        $sql = 'INSERT IGNORE INTO ' . _DB_PREFIX_ . "gls_cart_carrier VALUES (
                 '" . (int) $cart->id . "',
                 '" . (int) $cart->id_customer . "',
                 '" . (int) Configuration::get('GLS_GLSRELAIS_ID', (int) $cart->id_carrier, $cart->id_shop_group, $cart->id_shop) . "',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In case of import orders with GLS, the rule trigger a fatal error whith PS 1.6.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 47842
| How to test?  | 