### PR TITLE
Do not look for a point id if an order comes from eBay (48460)

### DIFF
--- a/src/OrderImport/Rules/ColissimoRule.php
+++ b/src/OrderImport/Rules/ColissimoRule.php
@@ -99,6 +99,11 @@ class ColissimoRule extends RuleAbstract implements RuleInterface
         return false;
     }
 
+    protected function isEbay(OrderResource $apiOrder)
+    {
+        return (bool) preg_match('#^ebay#i', $apiOrder->getChannel()->getName());
+    }
+
     protected function isZalando(OrderResource $apiOrder)
     {
         $apiOrderData = $apiOrder->toArray();
@@ -352,7 +357,9 @@ class ColissimoRule extends RuleAbstract implements RuleInterface
             return $apiOrderData['shippingAddress']['relayId'];
         }
         if (false === empty($apiOrderData['shippingAddress']['other'])) {
-            return $apiOrderData['shippingAddress']['other'];
+            if (false === $this->isEbay($apiOrder)) {
+                return $apiOrderData['shippingAddress']['other'];
+            }
         }
         if (false === empty($apiOrderData['shippingAddress']['relayID'])) {
             return $apiOrderData['shippingAddress']['relayID'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | do not look for a colissimo point id if an order comes from eBay
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 48460
| How to test?  | Please indicate how to best verify that this PR is correct.