### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/views/js/form_config_filter.js
+++ b/views/js/form_config_filter.js
@@ -50,7 +50,7 @@ $(document).ready(function() {
         product_rule_line.attr('data-type', $( "#product_rule_type option:selected").val());
         product_rule_line.find(".product_input input:eq(0)")
                          .attr('name', 'product_rule_select[' + $("#product_rule_type option:selected").val() + '][]');
-        product_rule_line.find('.type').html($( "#product_rule_type option:selected" ).text());
+        product_rule_line.find('.type').text($( "#product_rule_type option:selected" ).text());
         $('#product_rule_table tbody').append(product_rule_line);
     });
 


### PR DESCRIPTION
Fixes [https://github.com/shoppingflux/module-prestashop/security/code-scanning/1](https://github.com/shoppingflux/module-prestashop/security/code-scanning/1)

To fix the problem, we need to ensure that the text retrieved from the DOM is properly escaped before being inserted as HTML. This can be achieved by using a method that sets the text content instead of HTML content, such as `.text()` instead of `.html()`. This will prevent any HTML meta-characters in the text from being interpreted as HTML.

- Replace the use of `.html()` with `.text()` to ensure that the text is properly escaped.
- Specifically, change line 53 in the file `views/js/form_config_filter.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
