### PR TITLE
Fix mapping prestashop product (50520)

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -656,10 +656,15 @@ class Shoppingfeed extends \ShoppingfeedClasslib\Module
         $explodedReference = explode('_', $sfProductReference);
         $id_product = isset($explodedReference[0]) ? $explodedReference[0] : null;
 
-        $product = new Product($id_product, true, null, $id_shop);
-        $product->id_product_attribute = null;
-        if (isset($explodedReference[1])) {
+        if ($this->tools->isInt($id_product)) {
+            $product = new Product($id_product, true, null, $id_shop);
+        } else {
+            $product = new Product();
+        }
+        if (isset($explodedReference[1]) && $this->tools->isInt($explodedReference[1])) {
             $product->id_product_attribute = $explodedReference[1];
+        } else {
+            $product->id_product_attribute = null;
         }
 
         Hook::exec(

--- a/src/Services/SfTools.php
+++ b/src/Services/SfTools.php
@@ -20,6 +20,7 @@
 namespace ShoppingfeedAddon\Services;
 
 use Tools;
+use Validate;
 
 class SfTools
 {
@@ -30,5 +31,10 @@ class SfTools
         } else {
             return Tools::hash($string);
         }
+    }
+
+    public function isInt($value)
+    {
+        return Validate::isInt($value);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If an reference association is 'Default value (ID product with ID combination)' then a reference like '4G-WYBQ-FKKN' is parsed incorrect. Expected result is no product found, actual result is a product with id 4.
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes 50520
| How to test?  | Please indicate how to best verify that this PR is correct.
