### PR TITLE
 Fix mapping prestashop product (50521) #408 

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -685,10 +685,15 @@ class Shoppingfeed extends ShoppingfeedClasslib\Module
         $explodedReference = explode('_', $sfProductReference);
         $id_product = isset($explodedReference[0]) ? $explodedReference[0] : null;
 
-        $product = new Product($id_product, true, null, $id_shop);
-        $product->id_product_attribute = null;
-        if (isset($explodedReference[1])) {
+        if ($this->tools->isInt($id_product)) {
+            $product = new Product($id_product, true, null, $id_shop);
+        } else {
+            $product = new Product();
+        }
+        if (isset($explodedReference[1]) && $this->tools->isInt($explodedReference[1])) {
             $product->id_product_attribute = $explodedReference[1];
+        } else {
+            $product->id_product_attribute = null;
         }
 
         Hook::exec(

--- a/src/Services/SfTools.php
+++ b/src/Services/SfTools.php
@@ -20,22 +20,19 @@
 
 namespace ShoppingfeedAddon\Services;
 
-use Tools;
-use Validate;
-
 class SfTools
 {
     public function hash($string)
     {
         if (version_compare(_PS_VERSION_, '1.7', '<')) {
-            return Tools::encrypt($string);
+            return \Tools::encrypt($string);
         } else {
-            return Tools::hash($string);
+            return \Tools::hash($string);
         }
     }
 
     public function isInt($value)
     {
-        return Validate::isInt($value);
+        return \Validate::isInt($value);
     }
 }

--- a/src/Services/SfTools.php
+++ b/src/Services/SfTools.php
@@ -20,14 +20,22 @@
 
 namespace ShoppingfeedAddon\Services;
 
+use Tools;
+use Validate;
+
 class SfTools
 {
     public function hash($string)
     {
         if (version_compare(_PS_VERSION_, '1.7', '<')) {
-            return \Tools::encrypt($string);
+            return Tools::encrypt($string);
         } else {
-            return \Tools::hash($string);
+            return Tools::hash($string);
         }
+    }
+
+    public function isInt($value)
+    {
+        return Validate::isInt($value);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If an reference association is 'Default value (ID product with ID combination)' then a reference like '4G-WYBQ-FKKN' is parsed incorrect. Expected result is no product found, actual result is a product with id 4.
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | 50521
| How to test?  | Please indicate how to best verify that this PR is correct.
