### PR TITLE
refs #43794 block notification about an order status update

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1602,9 +1602,6 @@ class Shoppingfeed extends ShoppingfeedClasslib\Module
 
     public function hookActionEmailSendBefore($params)
     {
-        if ($params['$template'] !== 'order_conf') {
-            return true;
-        }
         if (empty($params['templateVars']['{order_name}'])) {
             return true;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | A goal is blocking not only order confirmation messages but messages about an order status update
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
