### PR TITLE
refs #50038 filtering order by date

### DIFF
--- a/src/OrderImport/Rules/ShippedByMarketplace.php
+++ b/src/OrderImport/Rules/ShippedByMarketplace.php
@@ -331,7 +331,7 @@ class ShippedByMarketplace extends RuleAbstract implements RuleInterface
         }
     }
 
-    protected function isShippedByMarketplace(OrderResource $apiOrder)
+    public function isShippedByMarketplace(OrderResource $apiOrder)
     {
         if ($this->isShippedAmazon($apiOrder)) {
             return true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If order is considered as both 'shipped by marketplace' and 'shipped' the restriction import date which should be taken into an account is one for 'shipped by marketplace'.
| Type?         | improvement
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
