### PR TITLE
Do not retry order sync after 3 months (51741)

### DIFF
--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -104,17 +104,6 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
             return false;
         }
 
-        if (false === Shoppingfeed::isOrderEligibleToSync($order)) {
-            ProcessLoggerHandler::logError(
-                $logPrefix . ' ' .
-                $this->l('Order was imported more than 3 months ago', 'ShoppingfeedOrderSyncActions'),
-                'Order',
-                $id_order
-            );
-
-            return false;
-        }
-
         if (empty($this->conveyor['order_action'])) {
             ProcessLoggerHandler::logError(
                 $logPrefix . ' ' .

--- a/classes/actions/ShoppingfeedOrderSyncActions.php
+++ b/classes/actions/ShoppingfeedOrderSyncActions.php
@@ -104,6 +104,19 @@ class ShoppingfeedOrderSyncActions extends DefaultActions
             return false;
         }
 
+        $orderCreationDate = DateTime::createFromFormat('Y-m-d H:i:s', $order->date_add);
+
+        if ($orderCreationDate && (time() - $orderCreationDate->getTimestamp() > 60 * 60 * 24 * 90)) {
+            ProcessLoggerHandler::logError(
+                $logPrefix . ' ' .
+                $this->l('Order was imported more than 3 months ago', 'ShoppingfeedOrderSyncActions'),
+                'Order',
+                $id_order
+            );
+
+            return false;
+        }
+
         if (empty($this->conveyor['order_action'])) {
             ProcessLoggerHandler::logError(
                 $logPrefix . ' ' .

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -602,6 +602,17 @@ class Shoppingfeed extends ShoppingfeedClasslib\Module
         return true;
     }
 
+    public static function isOrderEligibleToSync(Order $order)
+    {
+        $orderCreationDate = DateTime::createFromFormat('Y-m-d H:i:s', $order->date_add);
+
+        if ($orderCreationDate && (time() - $orderCreationDate->getTimestamp() > 60 * 60 * 24 * 90)) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Checks if order import can be activated
      *


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Do not sync orders that were imported more than 3 months ago
| Type?         | improvement
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
