### PR TITLE
Allow sending email for ps_emailalert (52096)

### DIFF
--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1607,7 +1607,7 @@ class Shoppingfeed extends ShoppingfeedClasslib\Module
 
     public function hookActionEmailSendBefore($params)
     {
-        if ($params['template'] === 'new_order' || empty($params['templateVars']['{order_name}'])) {
+        if ($params['template'] === 'new_order' ||  empty($params['templateVars']['{order_name}'])) {
             return true;
         }
 

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1607,7 +1607,7 @@ class Shoppingfeed extends ShoppingfeedClasslib\Module
 
     public function hookActionEmailSendBefore($params)
     {
-        if (empty($params['templateVars']['{order_name}'])) {
+        if ($params['template'] === 'new_order' || empty($params['templateVars']['{order_name}'])) {
             return true;
         }
 

--- a/shoppingfeed.php
+++ b/shoppingfeed.php
@@ -1607,7 +1607,7 @@ class Shoppingfeed extends ShoppingfeedClasslib\Module
 
     public function hookActionEmailSendBefore($params)
     {
-        if ($params['template'] === 'new_order' ||  empty($params['templateVars']['{order_name}'])) {
+        if ($params['template'] === 'new_order' || empty($params['templateVars']['{order_name}'])) {
             return true;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If send email in the module is set  to no in the module, allow notifications of new orders to the administator from the ps_emailalert module.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 52096
| How to test?  | NC
