### PR TITLE
refs #52743 fix. removing an imported order product when it matches w…

### DIFF
--- a/classes/actions/ShoppingfeedOrderImportActions.php
+++ b/classes/actions/ShoppingfeedOrderImportActions.php
@@ -1041,6 +1041,8 @@ class ShoppingfeedOrderImportActions extends DefaultActions
                 'unit_price_tax_incl' => (float) $apiProduct->unitPrice,
                 'unit_price_tax_excl' => (float) ((float) $apiProduct->unitPrice / (1 + ($tax_rate / 100))),
                 'original_product_price' => $original_product_price,
+                'product_quantity' => $apiProduct->quantity,
+                'product_quantity_in_stock' => $apiProduct->quantity,
             ];
             Db::getInstance()->update(
                 'order_detail',
@@ -1204,6 +1206,16 @@ class ShoppingfeedOrderImportActions extends DefaultActions
             //Looking for gift product
             foreach ($cartRules as $cartRule) {
                 if (empty($cartRule['gift_product'])) {
+                    continue;
+                }
+                $removeGift = true;
+                foreach ($this->conveyor['prestashopProducts'] as $psProduct) {
+                    if ($psProduct->id == $cartRule['gift_product'] && $psProduct->id_product_attribute == $cartRule['gift_product_attribute']) {
+                        $removeGift = false;
+                    }
+                }
+
+                if ($removeGift === false) {
                     continue;
                 }
                 //Deleting the gift product


### PR DESCRIPTION
…ith a gift product

<!-----------------------------------------------------------------------------
Thank you for contributing to the Shoppingfeed PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Removing an imported order product when it matches with a gift product
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
