### PR TITLE
Remove comma in method syntax error under php 8

### DIFF
--- a/classes/ShoppingfeedApi.php
+++ b/classes/ShoppingfeedApi.php
@@ -324,7 +324,7 @@ class ShoppingfeedApi
                         $operation->refund(
                             new Id((int) $taskOrder['id_internal_shoppingfeed']),
                             $taskOrder['payload']['shipping'] ?? '',
-                            $taskOrder['payload']['products'] ?? [],
+                            $taskOrder['payload']['products'] ?? []
                         );
                         continue 2;
                     case Shoppingfeed::ORDER_OPERATION_DELIVER:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Error message on log when launching order task: Connot import order : syntax error, unexpected ')' modules/shoppingfeed/classes/ShoppingfeedApi.php:328
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Import an order.