### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,5 +1,7 @@
 name: Coding Standart
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
     # Check there is no syntax errors in the project
     php-linter:


### PR DESCRIPTION
Potential fix for [https://github.com/shoppingflux/module-prestashop/security/code-scanning/6](https://github.com/shoppingflux/module-prestashop/security/code-scanning/6)

In general, the fix is to declare a `permissions:` block that limits the `GITHUB_TOKEN` to the least privileges needed. This can be done at the workflow root so it applies to all jobs, or per job. Since all jobs here are purely CI checks (linting, coding standards, static analysis) and do not need to write to the repository, we can safely restrict the token to `contents: read`. GitHub recommends explicitly declaring this even for read-only usage.

The best fix without changing functionality is to add a single workflow‑level `permissions:` block after the `on:` line, setting `contents: read`. This automatically applies to `php-linter`, `php-cs-fixer`, and `phpstan`, and no job overrides are needed because none of them require write scopes or other permissions. No additional methods, imports, or definitions are required; it’s just a YAML configuration change in `.github/workflows/php.yml`.

Concretely:
- Edit `.github/workflows/php.yml`.
- After line 2 (`on: [pull_request]`), insert:

```yaml
permissions:
  contents: read
```

This explicitly limits the `GITHUB_TOKEN` to read-only access to repository contents, satisfying CodeQL’s recommendation and following the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
