### PR TITLE
Product ean13 as reference in case of empty with combinations (57196)

### DIFF
--- a/classes/ShoppingfeedProduct.php
+++ b/classes/ShoppingfeedProduct.php
@@ -142,6 +142,10 @@ class ShoppingfeedProduct extends ObjectModel
         $sql->where($where);
         $reference = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
 
+        if (empty($reference) && empty($this->id_product_attribute) && $reference_format === 'ean13') {
+            $reference = (string) $this->id_product;
+        }
+
         return is_string($reference) ? trim($reference) : '';
     }
 

--- a/classes/ShoppingfeedProduct.php
+++ b/classes/ShoppingfeedProduct.php
@@ -143,7 +143,11 @@ class ShoppingfeedProduct extends ObjectModel
         $reference = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
 
         if (empty($reference) && empty($this->id_product_attribute) && $reference_format === 'ean13') {
-            $reference = (string) $this->id_product;
+            $hasCombintions = !empty(Product::getProductAttributesIds((int) $this->id_product));
+
+            if ($hasCombintions) {
+                $reference = (string) $this->id_product;
+            }
         }
 
         return is_string($reference) ? trim($reference) : '';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix Product ean13 as reference in case of empty with combinations (57196)
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 57196

